### PR TITLE
PHP 8.4 support

### DIFF
--- a/generator/lib/behavior/SoftDeleteBehavior.php
+++ b/generator/lib/behavior/SoftDeleteBehavior.php
@@ -59,7 +59,7 @@ class SoftDeleteBehavior extends Behavior
 /**
  * Bypass the soft_delete behavior and force a hard delete of the current object
  */
-public function forceDelete(PropelPDO \$con = null)
+public function forceDelete(?PropelPDO \$con = null)
 {
     if (\$isSoftDeleteEnabled = {$peerClassName}::isSoftDeleteEnabled()) { {$peerClassName}::disableSoftDelete();
     }
@@ -80,7 +80,7 @@ public function forceDelete(PropelPDO \$con = null)
  *
  * @return		 int The number of rows affected by this update and any referring fk objects' save() operations.
  */
-public function unDelete(PropelPDO \$con = null)
+public function unDelete(?PropelPDO \$con = null)
 {
     \$this->{$this->getColumnSetter()}(null);
 
@@ -172,7 +172,7 @@ public function includeDeleted()
  *
  * @return		int Number of updated rows
  */
-public function softDelete(PropelPDO \$con = null)
+public function softDelete(?PropelPDO \$con = null)
 {
     return \$this->update(array('{$this->getColumnForParameter('deleted_column')->getPhpName()}' => time()), \$con);
 }
@@ -189,7 +189,7 @@ public function softDelete(PropelPDO \$con = null)
  *
  * @return		int Number of deleted rows
  */
-public function forceDelete(PropelPDO \$con = null)
+public function forceDelete(?PropelPDO \$con = null)
 {
     return {$this->builder->getPeerClassname()}::doForceDelete(\$this, \$con);
 }
@@ -206,7 +206,7 @@ public function forceDelete(PropelPDO \$con = null)
  *
  * @return		int Number of deleted rows
  */
-public function forceDeleteAll(PropelPDO \$con = null)
+public function forceDeleteAll(?PropelPDO \$con = null)
 {
     return {$this->builder->getPeerClassname()}::doForceDeleteAll(\$con);}
 ";
@@ -222,7 +222,7 @@ public function forceDeleteAll(PropelPDO \$con = null)
  *
  * @return		int The number of rows affected by this update and any referring fk objects' save() operations.
  */
-public function unDelete(PropelPDO \$con = null)
+public function unDelete(?PropelPDO \$con = null)
 {
     return \$this->update(array('{$this->getColumnForParameter('deleted_column')->getPhpName()}' => null), \$con);
 }
@@ -362,7 +362,7 @@ public static function isSoftDeleteEnabled()
  * @throws		 PropelException Any exceptions caught during processing will be
  *							rethrown wrapped into a PropelException.
  */
-public static function doSoftDelete(\$values, PropelPDO \$con = null)
+public static function doSoftDelete(\$values, ?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection({$this->getTable()->getPhpName()}Peer::DATABASE_NAME, Propel::CONNECTION_WRITE);
@@ -414,7 +414,7 @@ public static function doSoftDelete(\$values, PropelPDO \$con = null)
  * @throws		 PropelException Any exceptions caught during processing will be
  *							rethrown wrapped into a PropelException.
  */
-public static function doDelete2(\$values, PropelPDO \$con = null)
+public static function doDelete2(\$values, ?PropelPDO \$con = null)
 {
     if ({$this->builder->getPeerClassname()}::isSoftDeleteEnabled()) {
         return {$this->builder->getPeerClassname()}::doSoftDelete(\$values, \$con);
@@ -435,7 +435,7 @@ public static function doDelete2(\$values, PropelPDO \$con = null)
  * @throws		 PropelException Any exceptions caught during processing will be
  *							rethrown wrapped into a PropelException.
  */
-public static function doSoftDeleteAll(PropelPDO \$con = null)
+public static function doSoftDeleteAll(?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection({$this->builder->getPeerClassname()}::DATABASE_NAME, Propel::CONNECTION_WRITE);
@@ -462,7 +462,7 @@ public static function doSoftDeleteAll(PropelPDO \$con = null)
  * @throws		 PropelException Any exceptions caught during processing will be
  *							rethrown wrapped into a PropelException.
  */
-public static function doDeleteAll2(PropelPDO \$con = null)
+public static function doDeleteAll2(?PropelPDO \$con = null)
 {
     if ({$this->builder->getPeerClassname()}::isSoftDeleteEnabled()) {
         return {$this->builder->getPeerClassname()}::doSoftDeleteAll(\$con);

--- a/generator/lib/behavior/aggregate_column/AggregateColumnRelationBehavior.php
+++ b/generator/lib/behavior/aggregate_column/AggregateColumnRelationBehavior.php
@@ -63,7 +63,7 @@ class AggregateColumnRelationBehavior extends Behavior
     {
         $relationName = $this->getRelationName($builder);
         $relatedClass = $this->getForeignTable()->getPhpName();
-        $search = "public function set{$relationName}({$relatedClass} \$v = null)
+        $search = "public function set{$relationName}(?{$relatedClass} \$v = null)
     {";
         $replace = $search . "
         // aggregate_column_relation behavior

--- a/generator/lib/behavior/archivable/templates/objectArchive.php
+++ b/generator/lib/behavior/archivable/templates/objectArchive.php
@@ -10,7 +10,7 @@
  *
  * @return     <?php echo $archiveTablePhpName ?> The archive object based on this object
  */
-public function archive(PropelPDO $con = null)
+public function archive(?PropelPDO $con = null)
 {
     if ($this->isNew()) {
         throw new PropelException('New objects cannot be archived. You must save the current object before calling archive().');

--- a/generator/lib/behavior/archivable/templates/objectDeleteWithoutArchive.php
+++ b/generator/lib/behavior/archivable/templates/objectDeleteWithoutArchive.php
@@ -5,7 +5,7 @@
  *
  * @return     <?php echo $objectClassname ?> The current object (for fluent API support)
  */
-public function deleteWithoutArchive(PropelPDO $con = null)
+public function deleteWithoutArchive(?PropelPDO $con = null)
 {
     $this->archiveOnDelete = false;
 

--- a/generator/lib/behavior/archivable/templates/objectGetArchive.php
+++ b/generator/lib/behavior/archivable/templates/objectGetArchive.php
@@ -5,7 +5,7 @@
  *
  * @return     <?php echo $archiveTablePhpName ?> An archive object, or null if the current object was never archived
  */
-public function getArchive(PropelPDO $con = null)
+public function getArchive(?PropelPDO $con = null)
 {
     if ($this->isNew()) {
         return null;

--- a/generator/lib/behavior/archivable/templates/objectRestoreFromArchive.php
+++ b/generator/lib/behavior/archivable/templates/objectRestoreFromArchive.php
@@ -8,7 +8,7 @@
  *
  * @return <?php echo $objectClassname ?> The current object (for fluent API support)
  */
-public function restoreFromArchive(PropelPDO $con = null)
+public function restoreFromArchive(?PropelPDO $con = null)
 {
     if (!$archive = $this->getArchive($con)) {
         throw new PropelException('The current object has never been archived and cannot be restored');

--- a/generator/lib/behavior/archivable/templates/objectSaveWithoutArchive.php
+++ b/generator/lib/behavior/archivable/templates/objectSaveWithoutArchive.php
@@ -5,7 +5,7 @@
  *
  * @return     <?php echo $objectClassname ?> The current object (for fluent API support)
  */
-public function saveWithoutArchive(PropelPDO $con = null)
+public function saveWithoutArchive(?PropelPDO $con = null)
 {
 <?php if (!$isArchiveOnInsert): ?>
     if (!$this->isNew()) {

--- a/generator/lib/behavior/i18n/templates/objectGetCurrentTranslation.php
+++ b/generator/lib/behavior/i18n/templates/objectGetCurrentTranslation.php
@@ -5,7 +5,7 @@
  *
  * @return <?php echo $i18nTablePhpName ?>
  */
-public function getCurrentTranslation(PropelPDO $con = null)
+public function getCurrentTranslation(?PropelPDO $con = null)
 {
     return $this->getTranslation($this->getLocale(), $con);
 }

--- a/generator/lib/behavior/i18n/templates/objectGetTranslation.php
+++ b/generator/lib/behavior/i18n/templates/objectGetTranslation.php
@@ -6,7 +6,7 @@
  *
  * @return <?php echo $i18nTablePhpName ?>
  */
-public function getTranslation($locale = '<?php echo $defaultLocale ?>', PropelPDO $con = null)
+public function getTranslation($locale = '<?php echo $defaultLocale ?>', ?PropelPDO $con = null)
 {
     if (!isset($this->currentTranslations[$locale])) {
         if (null !== $this-><?php echo $i18nListVariable ?>) {

--- a/generator/lib/behavior/i18n/templates/objectRemoveTranslation.php
+++ b/generator/lib/behavior/i18n/templates/objectRemoveTranslation.php
@@ -6,7 +6,7 @@
  *
  * @return    <?php echo $objectClassname ?> The current object (for fluent API support)
  */
-public function removeTranslation($locale = '<?php echo $defaultLocale ?>', PropelPDO $con = null)
+public function removeTranslation($locale = '<?php echo $defaultLocale ?>', ?PropelPDO $con = null)
 {
     if (!$this->isNew()) {
         <?php echo $i18nQueryName ?>::create()

--- a/generator/lib/behavior/nestedset/NestedSetBehaviorObjectBuilderModifier.php
+++ b/generator/lib/behavior/nestedset/NestedSetBehaviorObjectBuilderModifier.php
@@ -501,7 +501,7 @@ public function isAncestorOf(\$child)
  * @param      PropelPDO \$con Connection to use.
  * @return     bool
  */
-public function hasParent(PropelPDO \$con = null)
+public function hasParent(?PropelPDO \$con = null)
 {
     return \$this->getLevel() > 0;
 }
@@ -539,7 +539,7 @@ public function setParent(\$parent = null)
  * @param      PropelPDO \$con Connection to use.
  * @return     mixed 		Propel object if exists else false
  */
-public function getParent(PropelPDO \$con = null)
+public function getParent(?PropelPDO \$con = null)
 {
     if (\$this->aNestedSetParent === null && \$this->hasParent()) {
         \$this->aNestedSetParent = {$this->queryClassname}::create()
@@ -564,7 +564,7 @@ public function getParent(PropelPDO \$con = null)
  * @param      PropelPDO \$con Connection to use.
  * @return     bool
  */
-public function hasPrevSibling(PropelPDO \$con = null)
+public function hasPrevSibling(?PropelPDO \$con = null)
 {
     if (!{$this->peerClassname}::isValid(\$this)) {
         return false;
@@ -592,7 +592,7 @@ public function hasPrevSibling(PropelPDO \$con = null)
  * @param      PropelPDO \$con Connection to use.
  * @return     mixed 		Propel object if exists else false
  */
-public function getPrevSibling(PropelPDO \$con = null)
+public function getPrevSibling(?PropelPDO \$con = null)
 {
     return $queryClassname::create()
         ->filterBy" . $this->getColumnPhpName('right_column') . "(\$this->getLeftValue() - 1)";
@@ -617,7 +617,7 @@ public function getPrevSibling(PropelPDO \$con = null)
  * @param      PropelPDO \$con Connection to use.
  * @return     bool
  */
-public function hasNextSibling(PropelPDO \$con = null)
+public function hasNextSibling(?PropelPDO \$con = null)
 {
     if (!{$this->peerClassname}::isValid(\$this)) {
         return false;
@@ -645,7 +645,7 @@ public function hasNextSibling(PropelPDO \$con = null)
  * @param      PropelPDO \$con Connection to use.
  * @return     mixed 		Propel object if exists else false
  */
-public function getNextSibling(PropelPDO \$con = null)
+public function getNextSibling(?PropelPDO \$con = null)
 {
     return $queryClassname::create()
         ->filterBy" . $this->getColumnPhpName('left_column') . "(\$this->getRightValue() + 1)";
@@ -747,7 +747,7 @@ public function hasChildren()
  * @param      PropelPDO \$con Connection to use.
  * @return     array     List of $objectClassname objects
  */
-public function getChildren(\$criteria = null, PropelPDO \$con = null)
+public function getChildren(\$criteria = null, ?PropelPDO \$con = null)
 {
     if (null === \$this->collNestedSetChildren || null !== \$criteria) {
         if (\$this->isLeaf() || (\$this->isNew() && null === \$this->collNestedSetChildren)) {
@@ -782,7 +782,7 @@ public function getChildren(\$criteria = null, PropelPDO \$con = null)
  * @param      PropelPDO \$con Connection to use.
  * @return     int       Number of children
  */
-public function countChildren(\$criteria = null, PropelPDO \$con = null)
+public function countChildren(\$criteria = null, ?PropelPDO \$con = null)
 {
     if (null === \$this->collNestedSetChildren || null !== \$criteria) {
         if (\$this->isLeaf() || (\$this->isNew() && null === \$this->collNestedSetChildren)) {
@@ -811,7 +811,7 @@ public function countChildren(\$criteria = null, PropelPDO \$con = null)
  * @param      PropelPDO \$con Connection to use.
  * @return     array 		List of $objectClassname objects
  */
-public function getFirstChild(\$query = null, PropelPDO \$con = null)
+public function getFirstChild(\$query = null, ?PropelPDO \$con = null)
 {
     if (\$this->isLeaf()) {
         return array();
@@ -837,7 +837,7 @@ public function getFirstChild(\$query = null, PropelPDO \$con = null)
  * @param      PropelPDO \$con Connection to use.
  * @return     array 		List of $objectClassname objects
  */
-public function getLastChild(\$query = null, PropelPDO \$con = null)
+public function getLastChild(\$query = null, ?PropelPDO \$con = null)
 {
     if (\$this->isLeaf()) {
         return array();
@@ -865,7 +865,7 @@ public function getLastChild(\$query = null, PropelPDO \$con = null)
  *
  * @return     array 		List of $objectClassname objects
  */
-public function getSiblings(\$includeNode = false, \$query = null, PropelPDO \$con = null)
+public function getSiblings(\$includeNode = false, \$query = null, ?PropelPDO \$con = null)
 {
     if (\$this->isRoot()) {
         return array();
@@ -895,7 +895,7 @@ public function getSiblings(\$includeNode = false, \$query = null, PropelPDO \$c
  * @param      PropelPDO \$con Connection to use.
  * @return     array 		List of $objectClassname objects
  */
-public function getDescendants(\$query = null, PropelPDO \$con = null)
+public function getDescendants(\$query = null, ?PropelPDO \$con = null)
 {
     if (\$this->isLeaf()) {
         return array();
@@ -921,7 +921,7 @@ public function getDescendants(\$query = null, PropelPDO \$con = null)
  * @param      PropelPDO \$con Connection to use.
  * @return     int 		Number of descendants
  */
-public function countDescendants(\$query = null, PropelPDO \$con = null)
+public function countDescendants(\$query = null, ?PropelPDO \$con = null)
 {
     if (\$this->isLeaf()) {
         // save one query
@@ -947,7 +947,7 @@ public function countDescendants(\$query = null, PropelPDO \$con = null)
  * @param      PropelPDO \$con Connection to use.
  * @return     array 		List of $objectClassname objects
  */
-public function getBranch(\$query = null, PropelPDO \$con = null)
+public function getBranch(\$query = null, ?PropelPDO \$con = null)
 {
     return $queryClassname::create(null, \$query)
         ->branchOf(\$this)
@@ -970,7 +970,7 @@ public function getBranch(\$query = null, PropelPDO \$con = null)
  * @param      PropelPDO \$con Connection to use.
  * @return     array 		List of $objectClassname objects
  */
-public function getAncestors(\$query = null, PropelPDO \$con = null)
+public function getAncestors(\$query = null, ?PropelPDO \$con = null)
 {
     if (\$this->isRoot()) {
         // save one query
@@ -1208,7 +1208,7 @@ public function insertAsNextSiblingOf(\$sibling)
  *
  * @return     $objectClassname The current Propel object
  */
-public function moveToFirstChildOf(\$parent, PropelPDO \$con = null)
+public function moveToFirstChildOf(\$parent, ?PropelPDO \$con = null)
 {
     if (!\$this->isInTree()) {
         throw new PropelException('A $objectClassname object must be already in the tree to be moved. Use the insertAsFirstChildOf() instead.');
@@ -1238,7 +1238,7 @@ public function moveToFirstChildOf(\$parent, PropelPDO \$con = null)
  *
  * @return     $objectClassname The current Propel object
  */
-public function moveToLastChildOf(\$parent, PropelPDO \$con = null)
+public function moveToLastChildOf(\$parent, ?PropelPDO \$con = null)
 {
     if (!\$this->isInTree()) {
         throw new PropelException('A $objectClassname object must be already in the tree to be moved. Use the insertAsLastChildOf() instead.');
@@ -1268,7 +1268,7 @@ public function moveToLastChildOf(\$parent, PropelPDO \$con = null)
  *
  * @return     $objectClassname The current Propel object
  */
-public function moveToPrevSiblingOf(\$sibling, PropelPDO \$con = null)
+public function moveToPrevSiblingOf(\$sibling, ?PropelPDO \$con = null)
 {
     if (!\$this->isInTree()) {
         throw new PropelException('A $objectClassname object must be already in the tree to be moved. Use the insertAsPrevSiblingOf() instead.');
@@ -1301,7 +1301,7 @@ public function moveToPrevSiblingOf(\$sibling, PropelPDO \$con = null)
  *
  * @return     $objectClassname The current Propel object
  */
-public function moveToNextSiblingOf(\$sibling, PropelPDO \$con = null)
+public function moveToNextSiblingOf(\$sibling, ?PropelPDO \$con = null)
 {
     if (!\$this->isInTree()) {
         throw new PropelException('A $objectClassname object must be already in the tree to be moved. Use the insertAsNextSiblingOf() instead.');
@@ -1334,7 +1334,7 @@ public function moveToNextSiblingOf(\$sibling, PropelPDO \$con = null)
  * @param      int	\$levelDelta Delta to add to the levels
  * @param      PropelPDO \$con		Connection to use.
  */
-protected function moveSubtreeTo(\$destLeft, \$levelDelta" . ($this->behavior->useScope() ? ", \$targetScope = null" : "") . ", PropelPDO \$con = null)
+protected function moveSubtreeTo(\$destLeft, \$levelDelta" . ($this->behavior->useScope() ? ", \$targetScope = null" : "") . ", ?PropelPDO \$con = null)
 {
     \$preventDefault = false;
     \$left  = \$this->getLeftValue();
@@ -1442,7 +1442,7 @@ protected function moveSubtreeTo(\$destLeft, \$levelDelta" . ($this->behavior->u
  *
  * @return     int 		number of deleted nodes
  */
-public function deleteDescendants(PropelPDO \$con = null)
+public function deleteDescendants(?PropelPDO \$con = null)
 {
     if (\$this->isLeaf()) {
         // save one query
@@ -1519,7 +1519,7 @@ public function createRoot()
  * @deprecated since 1.5
  * @see        getParent
  */
-public function retrieveParent(PropelPDO \$con = null)
+public function retrieveParent(?PropelPDO \$con = null)
 {
     return \$this->getParent(\$con);
 }
@@ -1541,7 +1541,7 @@ public function setParentNode(\$parent = null)
  * @deprecated since 1.5
  * @see        setParent
  */
-public function getNumberOfDescendants(PropelPDO \$con = null)
+public function getNumberOfDescendants(?PropelPDO \$con = null)
 {
     return \$this->countDescendants(null, \$con);
 }
@@ -1552,7 +1552,7 @@ public function getNumberOfDescendants(PropelPDO \$con = null)
  * @deprecated since 1.5
  * @see        setParent
  */
-public function getNumberOfChildren(PropelPDO \$con = null)
+public function getNumberOfChildren(?PropelPDO \$con = null)
 {
     return \$this->countChildren(null, \$con);
 }
@@ -1563,7 +1563,7 @@ public function getNumberOfChildren(PropelPDO \$con = null)
  * @deprecated since 1.5
  * @see        getParent
  */
-public function retrievePrevSibling(PropelPDO \$con = null)
+public function retrievePrevSibling(?PropelPDO \$con = null)
 {
     return \$this->getPrevSibling(\$con);
 }
@@ -1574,7 +1574,7 @@ public function retrievePrevSibling(PropelPDO \$con = null)
  * @deprecated since 1.5
  * @see        getParent
  */
-public function retrieveNextSibling(PropelPDO \$con = null)
+public function retrieveNextSibling(?PropelPDO \$con = null)
 {
     return \$this->getNextSibling(\$con);
 }
@@ -1585,7 +1585,7 @@ public function retrieveNextSibling(PropelPDO \$con = null)
  * @deprecated since 1.5
  * @see        getParent
  */
-public function retrieveFirstChild(PropelPDO \$con = null)
+public function retrieveFirstChild(?PropelPDO \$con = null)
 {
     return \$this->getFirstChild(null, \$con);
 }
@@ -1596,7 +1596,7 @@ public function retrieveFirstChild(PropelPDO \$con = null)
  * @deprecated since 1.5
  * @see        getParent
  */
-public function retrieveLastChild(PropelPDO \$con = null)
+public function retrieveLastChild(?PropelPDO \$con = null)
 {
     return \$this->getLastChild(null, \$con);
 }
@@ -1607,7 +1607,7 @@ public function retrieveLastChild(PropelPDO \$con = null)
  * @deprecated since 1.5
  * @see        getAncestors
  */
-public function getPath(PropelPDO \$con = null)
+public function getPath(?PropelPDO \$con = null)
 {
     \$path = \$this->getAncestors(null, \$con);
     \$path []= \$this;

--- a/generator/lib/behavior/nestedset/NestedSetBehaviorPeerBuilderModifier.php
+++ b/generator/lib/behavior/nestedset/NestedSetBehaviorPeerBuilderModifier.php
@@ -123,7 +123,7 @@ const SCOPE_COL = '" . $tableName . '.' . $this->getColumnConstant('scope_column
  * @param      mixed     \$scope
  * @param      PropelPDO \$con	Connection to use.
  */
-public static function setNegativeScope(\$scope, PropelPDO \$con = null)
+public static function setNegativeScope(\$scope, ?PropelPDO \$con = null)
 {
     //adjust scope value to \$scope
     \$whereCriteria = new Criteria($peerClassname::DATABASE_NAME);
@@ -147,7 +147,7 @@ public static function setNegativeScope(\$scope, PropelPDO \$con = null)
  * @param      PropelPDO \$con	Connection to use.
  * @return     {$this->objectClassname}			Propel object for root node
  */
-public static function retrieveRoots(Criteria \$criteria = null, PropelPDO \$con = null)
+public static function retrieveRoots(?Criteria \$criteria = null, ?PropelPDO \$con = null)
 {
     if (\$criteria === null) {
         \$criteria = new Criteria($peerClassname::DATABASE_NAME);
@@ -175,7 +175,7 @@ public static function retrieveRoots(Criteria \$criteria = null, PropelPDO \$con
  * @param      PropelPDO \$con	Connection to use.
  * @return     {$this->objectClassname}			Propel object for root node
  */
-public static function retrieveRoot(" . ($useScope ? "\$scope = null, " : "") . "PropelPDO \$con = null)
+public static function retrieveRoot(" . ($useScope ? "\$scope = null, " : "") . "?PropelPDO \$con = null)
 {
     \$c = new Criteria($peerClassname::DATABASE_NAME);
     \$c->add($peerClassname::LEFT_COL, 1, Criteria::EQUAL);";
@@ -207,7 +207,7 @@ public static function retrieveRoot(" . ($useScope ? "\$scope = null, " : "") . 
  * @param      PropelPDO \$con	Connection to use.
  * @return     {$this->objectClassname}			Propel object for root node
  */
-public static function retrieveTree(" . ($useScope ? "\$scope = null, " : "") . "Criteria \$criteria = null, PropelPDO \$con = null)
+public static function retrieveTree(" . ($useScope ? "\$scope = null, " : "") . "?Criteria \$criteria = null, ?PropelPDO \$con = null)
 {
     if (\$criteria === null) {
         \$criteria = new Criteria($peerClassname::DATABASE_NAME);
@@ -234,7 +234,7 @@ public static function retrieveTree(" . ($useScope ? "\$scope = null, " : "") . 
  * @param      $objectClassname \$node	Propel object for src node
  * @return     bool
  */
-public static function isValid($objectClassname \$node = null)
+public static function isValid(?$objectClassname \$node = null)
 {
     if (is_object(\$node) && \$node->getRightValue() > \$node->getLeftValue()) {
         return true;
@@ -262,7 +262,7 @@ public static function isValid($objectClassname \$node = null)
  *
  * @return     int  The number of deleted nodes
  */
-public static function deleteTree(" . ($useScope ? "\$scope = null, " : "") . "PropelPDO \$con = null)
+public static function deleteTree(" . ($useScope ? "\$scope = null, " : "") . "?PropelPDO \$con = null)
 {";
         if ($useScope) {
             $script .= "
@@ -299,7 +299,7 @@ public static function deleteTree(" . ($useScope ? "\$scope = null, " : "") . "P
         $script .= "
  * @param      PropelPDO \$con		Connection to use.
  */
-public static function shiftRLValues(\$delta, \$first, \$last = null" . ($useScope ? ", \$scope = null" : "") . ", PropelPDO \$con = null)
+public static function shiftRLValues(\$delta, \$first, \$last = null" . ($useScope ? ", \$scope = null" : "") . ", ?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection($peerClassname::DATABASE_NAME, Propel::CONNECTION_WRITE);
@@ -363,7 +363,7 @@ public static function shiftRLValues(\$delta, \$first, \$last = null" . ($useSco
         $script .= "
  * @param      PropelPDO \$con		Connection to use.
  */
-public static function shiftLevel(\$delta, \$first, \$last" . ($useScope ? ", \$scope = null" : "") . ", PropelPDO \$con = null)
+public static function shiftLevel(\$delta, \$first, \$last" . ($useScope ? ", \$scope = null" : "") . ", ?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection($peerClassname::DATABASE_NAME, Propel::CONNECTION_WRITE);
@@ -397,7 +397,7 @@ public static function shiftLevel(\$delta, \$first, \$last" . ($useScope ? ", \$
  * @param      $objectClassname \$prune		Object to prune from the update
  * @param      PropelPDO \$con		Connection to use.
  */
-public static function updateLoadedNodes(\$prune = null, PropelPDO \$con = null)
+public static function updateLoadedNodes(\$prune = null, ?PropelPDO \$con = null)
 {
     if (Propel::isInstancePoolingEnabled()) {
         \$keys = array();
@@ -496,7 +496,7 @@ public static function updateLoadedNodes(\$prune = null, PropelPDO \$con = null)
  * @param      mixed \$prune	Object to prune from the shift
  * @param      PropelPDO \$con	Connection to use.
  */
-public static function makeRoomForLeaf(\$left" . ($useScope ? ", \$scope" : "") . ", \$prune = null, PropelPDO \$con = null)
+public static function makeRoomForLeaf(\$left" . ($useScope ? ", \$scope" : "") . ", \$prune = null, ?PropelPDO \$con = null)
 {
     // Update database nodes
     $peerClassname::shiftRLValues(2, \$left, null" . ($useScope ? ", \$scope" : "") . ", \$con);
@@ -522,7 +522,7 @@ public static function makeRoomForLeaf(\$left" . ($useScope ? ", \$scope" : "") 
         $script .= "
  * @param      PropelPDO \$con	Connection to use.
  */
-public static function fixLevels(" . ($useScope ? "\$scope, " : "") . "PropelPDO \$con = null)
+public static function fixLevels(" . ($useScope ? "\$scope, " : "") . "?PropelPDO \$con = null)
 {
     \$c = new Criteria();";
         if ($useScope) {

--- a/generator/lib/behavior/nestedset/NestedSetBehaviorQueryBuilderModifier.php
+++ b/generator/lib/behavior/nestedset/NestedSetBehaviorQueryBuilderModifier.php
@@ -187,7 +187,7 @@ public function childrenOf($objectName)
  *
  * @return    {$this->queryClassname} The current query, for fluid interface
  */
-public function siblingsOf($objectName, PropelPDO \$con = null)
+public function siblingsOf($objectName, ?PropelPDO \$con = null)
 {
     if ({$objectName}->isRoot()) {
         return \$this->

--- a/generator/lib/behavior/sortable/SortableBehaviorObjectBuilderModifier.php
+++ b/generator/lib/behavior/sortable/SortableBehaviorObjectBuilderModifier.php
@@ -359,7 +359,7 @@ public function isFirst()
  *
  * @return    boolean
  */
-public function isLast(PropelPDO \$con = null)
+public function isLast(?PropelPDO \$con = null)
 {
     return \$this->{$this->getColumnGetter()}() == {$this->queryClassname}::create()->getMaxRankArray(" . ($useScope ? "\$this->getScopeValue(), " : '') . "\$con);
 }
@@ -379,7 +379,7 @@ public function isLast(PropelPDO \$con = null)
  *
  * @return    {$this->objectClassname}
  */
-public function getNext(PropelPDO \$con = null)
+public function getNext(?PropelPDO \$con = null)
 {";
         $script .= "
 
@@ -422,7 +422,7 @@ public function getNext(PropelPDO \$con = null)
  *
  * @return    {$this->objectClassname}
  */
-public function getPrevious(PropelPDO \$con = null)
+public function getPrevious(?PropelPDO \$con = null)
 {";
         $script .= "
 
@@ -466,7 +466,7 @@ public function getPrevious(PropelPDO \$con = null)
  *
  * @throws    PropelException
  */
-public function insertAtRank(\$rank, PropelPDO \$con = null)
+public function insertAtRank(\$rank, ?PropelPDO \$con = null)
 {";
         $script .= "
     \$maxRank = {$this->queryClassname}::create()->getMaxRankArray(" . ($useScope ? "\$this->getScopeValue(), " : '') . "\$con);
@@ -502,7 +502,7 @@ public function insertAtRank(\$rank, PropelPDO \$con = null)
  *
  * @throws    PropelException
  */
-public function insertAtBottom(PropelPDO \$con = null)
+public function insertAtBottom(?PropelPDO \$con = null)
 {";
         $script .= "
     \$this->{$this->getColumnSetter()}({$this->queryClassname}::create()->getMaxRankArray(" . ($useScope ? "\$this->getScopeValue(), " : '') . "\$con) + 1);
@@ -544,7 +544,7 @@ public function insertAtTop()
  *
  * @throws    PropelException
  */
-public function moveToRank(\$newRank, PropelPDO \$con = null)
+public function moveToRank(\$newRank, ?PropelPDO \$con = null)
 {
     if (\$this->isNew()) {
         throw new PropelException('New objects cannot be moved. Please use insertAtRank() instead');
@@ -595,7 +595,7 @@ public function moveToRank(\$newRank, PropelPDO \$con = null)
  *
  * @throws Exception if the database cannot execute the two updates
  */
-public function swapWith(\$object, PropelPDO \$con = null)
+public function swapWith(\$object, ?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection({$this->peerClassname}::DATABASE_NAME);
@@ -639,7 +639,7 @@ $script .= "
  *
  * @return    {$this->objectClassname} the current object
  */
-public function moveUp(PropelPDO \$con = null)
+public function moveUp(?PropelPDO \$con = null)
 {
     if (\$this->isFirst()) {
         return \$this;
@@ -672,7 +672,7 @@ public function moveUp(PropelPDO \$con = null)
  *
  * @return    {$this->objectClassname} the current object
  */
-public function moveDown(PropelPDO \$con = null)
+public function moveDown(?PropelPDO \$con = null)
 {
     if (\$this->isLast(\$con)) {
         return \$this;
@@ -705,7 +705,7 @@ public function moveDown(PropelPDO \$con = null)
  *
  * @return    {$this->objectClassname} the current object
  */
-public function moveToTop(PropelPDO \$con = null)
+public function moveToTop(?PropelPDO \$con = null)
 {
     if (\$this->isFirst()) {
         return \$this;
@@ -727,7 +727,7 @@ public function moveToTop(PropelPDO \$con = null)
  *
  * @return integer the old object's rank
  */
-public function moveToBottom(PropelPDO \$con = null)
+public function moveToBottom(?PropelPDO \$con = null)
 {
     if (\$this->isLast(\$con)) {
         return false;
@@ -762,7 +762,7 @@ public function moveToBottom(PropelPDO \$con = null)
  *
  * @return    {$this->objectClassname} the current object
  */
-public function removeFromList(PropelPDO \$con = null)
+public function removeFromList(?PropelPDO \$con = null)
 {";
         if ($useScope) {
           $script .= "

--- a/generator/lib/behavior/sortable/SortableBehaviorPeerBuilderModifier.php
+++ b/generator/lib/behavior/sortable/SortableBehaviorPeerBuilderModifier.php
@@ -198,7 +198,7 @@ public static function sortableApplyScopeCriteria(Criteria \$criteria, \$scope, 
  *
  * @return    integer highest position
  */
-public static function getMaxRank(" . ($useScope ? "\$scope = null, " : "") . "PropelPDO \$con = null)
+public static function getMaxRank(" . ($useScope ? "\$scope = null, " : "") . "?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection({$this->peerClassname}::DATABASE_NAME);
@@ -236,7 +236,7 @@ public static function getMaxRank(" . ($useScope ? "\$scope = null, " : "") . "P
  *
  * @return {$this->objectClassname}
  */
-public static function retrieveByRank(\$rank, " . ($useScope ? "\$scope = null, " : "") . "PropelPDO \$con = null)
+public static function retrieveByRank(\$rank, " . ($useScope ? "\$scope = null, " : "") . "?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection($peerClassname::DATABASE_NAME);
@@ -271,7 +271,7 @@ public static function retrieveByRank(\$rank, " . ($useScope ? "\$scope = null, 
  *
  * @return    boolean true if the reordering took place, false if a database problem prevented it
  */
-public static function reorder(array \$order, PropelPDO \$con = null)
+public static function reorder(array \$order, ?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection($peerClassname::DATABASE_NAME);
@@ -312,7 +312,7 @@ public static function reorder(array \$order, PropelPDO \$con = null)
  *
  * @return    array list of sortable objects
  */
-public static function doSelectOrderByRank(Criteria \$criteria = null, \$order = Criteria::ASC, PropelPDO \$con = null)
+public static function doSelectOrderByRank(?Criteria \$criteria = null, \$order = Criteria::ASC, ?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection($peerClassname::DATABASE_NAME);
@@ -350,7 +350,7 @@ public static function doSelectOrderByRank(Criteria \$criteria = null, \$order =
  *
  * @return    array list of sortable objects
  */
-public static function retrieveList(\$scope, \$order = Criteria::ASC, PropelPDO \$con = null)
+public static function retrieveList(\$scope, \$order = Criteria::ASC, ?PropelPDO \$con = null)
 {
     \$c = new Criteria();
     {$this->peerClassname}::sortableApplyScopeCriteria(\$c, \$scope);
@@ -372,7 +372,7 @@ public static function retrieveList(\$scope, \$order = Criteria::ASC, PropelPDO 
  *
  * @return    array list of sortable objects
  */
-public static function countList(\$scope, PropelPDO \$con = null)
+public static function countList(\$scope, ?PropelPDO \$con = null)
 {
     \$c = new Criteria();
     {$this->peerClassname}::sortableApplyScopeCriteria(\$c, \$scope);
@@ -394,7 +394,7 @@ public static function countList(\$scope, PropelPDO \$con = null)
  *
  * @return    int number of deleted objects
  */
-public static function deleteList(\$scope, PropelPDO \$con = null)
+public static function deleteList(\$scope, ?PropelPDO \$con = null)
 {
     \$c = new Criteria();
     {$this->peerClassname}::sortableApplyScopeCriteria(\$c, \$scope);
@@ -422,7 +422,7 @@ public static function deleteList(\$scope, PropelPDO \$con = null)
         $script .= "
  * @param      PropelPDO \$con Connection to use.
  */
-public static function shiftRank(\$delta, \$first = null, \$last = null, " . ($useScope ? "\$scope = null, " : "") . "PropelPDO \$con = null)
+public static function shiftRank(\$delta, \$first = null, \$last = null, " . ($useScope ? "\$scope = null, " : "") . "?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection($peerClassname::DATABASE_NAME, Propel::CONNECTION_WRITE);

--- a/generator/lib/behavior/sortable/SortableBehaviorQueryBuilderModifier.php
+++ b/generator/lib/behavior/sortable/SortableBehaviorQueryBuilderModifier.php
@@ -208,7 +208,7 @@ $paramsDoc";
  *
  * @return    {$this->objectClassname}
  */
-public function findOneByRank(\$rank, " . ($useScope ? "$methodSignature, " : "") . "PropelPDO \$con = null)
+public function findOneByRank(\$rank, " . ($useScope ? "$methodSignature, " : "") . "?PropelPDO \$con = null)
 {";
 
         if ($useScope) {
@@ -291,7 +291,7 @@ $paramsDoc
  *
  * @return    integer highest position
  */
-public function getMaxRank(" . ($useScope ? "$methodSignature, " : "") . "PropelPDO \$con = null)
+public function getMaxRank(" . ($useScope ? "$methodSignature, " : "") . "?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection({$this->peerClassname}::DATABASE_NAME);
@@ -330,7 +330,7 @@ public function getMaxRank(" . ($useScope ? "$methodSignature, " : "") . "Propel
  *
  * @return    integer highest position
  */
-public function getMaxRankArray(" . ($useScope ? "\$scope, " : "") . "PropelPDO \$con = null)
+public function getMaxRankArray(" . ($useScope ? "\$scope, " : "") . "?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection({$this->peerClassname}::DATABASE_NAME);
@@ -366,7 +366,7 @@ public function getMaxRankArray(" . ($useScope ? "\$scope, " : "") . "PropelPDO 
  *
  * @return    boolean true if the reordering took place, false if a database problem prevented it
  */
-public function reorder(array \$order, PropelPDO \$con = null)
+public function reorder(array \$order, ?PropelPDO \$con = null)
 {
     if (\$con === null) {
         \$con = Propel::getConnection($peerClassname::DATABASE_NAME);

--- a/generator/lib/behavior/sortable/SortableRelationBehavior.php
+++ b/generator/lib/behavior/sortable/SortableRelationBehavior.php
@@ -76,7 +76,7 @@ class SortableRelationBehavior extends Behavior
  * Moves related {$this->getRelatedClassPluralForm()} to null scope
  * @param PropelPDO \$con A connection object
  */
-public function {$this->getObjectMoveRelatedToNullScopeMethodName()}(PropelPDO \$con = null)
+public function {$this->getObjectMoveRelatedToNullScopeMethodName()}(?PropelPDO \$con = null)
 {
     \$maxRank = $queryClass::create()->getMaxRank(\$this->getPrimaryKey(), \$con);
     if (null !== \$maxRank) { // getMaxRank() returns null for empty tables

--- a/generator/lib/behavior/versionable/VersionableBehaviorObjectBuilderModifier.php
+++ b/generator/lib/behavior/versionable/VersionableBehaviorObjectBuilderModifier.php
@@ -785,7 +785,7 @@ public function compareVersions(\$fromVersionNumber, \$toVersionNumber, \$keys =
  *
  * @return PropelCollection|{$versionARClassname}[] List of {$versionARClassname} objects
  */
-public function getLastVersions(\$number = 10, \$criteria = null, PropelPDO \$con = null)
+public function getLastVersions(\$number = 10, \$criteria = null, ?PropelPDO \$con = null)
 {
     \$criteria = {$this->getVersionQueryClassName()}::create(null, \$criteria);
     \$criteria->addDescendingOrderByColumn({$versionPeer}::VERSION);

--- a/generator/lib/builder/om/PHP5NestedSetBuilder.php
+++ b/generator/lib/builder/om/PHP5NestedSetBuilder.php
@@ -259,7 +259,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      *                 May be unreliable with parent/children/brother changes
      * @throws PropelException
      */
-    public function save(PropelPDO \$con = null)
+    public function save(?PropelPDO \$con = null)
     {
         \$left = \$this->getLeftValue();
         \$right = \$this->getRightValue();
@@ -284,7 +284,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @return void
      * @throws PropelException
      */
-    public function delete(PropelPDO \$con = null)
+    public function delete(?PropelPDO \$con = null)
     {
         // delete node first
         parent::delete(\$con);
@@ -325,7 +325,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO Connection to use.
      * @return int
      */
-    public function getLevel(PropelPDO \$con = null)
+    public function getLevel(?PropelPDO \$con = null)
     {
         if (null === \$this->level) {
             \$this->level = $peerClassname::getLevel(\$this, \$con);
@@ -385,7 +385,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param    $objectClassName \$parent Propel node object
      * @return   $objectClassName The current object (for fluent API support)
      */
-    public function setParentNode(NodeObject \$parent = null)
+    public function setParentNode(?NodeObject \$parent = null)
     {
         \$this->parentNode = (true === (\$this->hasParentNode = $peerClassname::isValid(\$parent))) ? \$parent : null;
 
@@ -405,7 +405,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param    $objectClassName \$node Propel node object
      * @return   $objectClassName The current object (for fluent API support)
      */
-    public function setPrevSibling(NodeObject \$node = null)
+    public function setPrevSibling(?NodeObject \$node = null)
     {
         \$this->prevSibling = \$node;
         \$this->hasPrevSibling = $peerClassname::isValid(\$node);
@@ -426,7 +426,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param    $objectClassName \$node Propel node object
      * @return   $objectClassName The current object (for fluent API support)
      */
-    public function setNextSibling(NodeObject \$node = null)
+    public function setNextSibling(?NodeObject \$node = null)
     {
         \$this->nextSibling = \$node;
         \$this->hasNextSibling = $peerClassname::isValid(\$node);
@@ -446,7 +446,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO Connection to use.
      * @return array
      */
-    public function getPath(PropelPDO \$con = null)
+    public function getPath(?PropelPDO \$con = null)
     {
         return $peerClassname::getPath(\$this, \$con);
     }
@@ -463,7 +463,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO Connection to use.
      * @return int
      */
-    public function getNumberOfChildren(PropelPDO \$con = null)
+    public function getNumberOfChildren(?PropelPDO \$con = null)
     {
         return $peerClassname::getNumberOfChildren(\$this, \$con);
     }
@@ -480,7 +480,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO Connection to use.
      * @return int
      */
-    public function getNumberOfDescendants(PropelPDO \$con = null)
+    public function getNumberOfDescendants(?PropelPDO \$con = null)
     {
         return $peerClassname::getNumberOfDescendants(\$this, \$con);
     }
@@ -497,7 +497,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO Connection to use.
      * @return array
      */
-    public function getChildren(PropelPDO \$con = null)
+    public function getChildren(?PropelPDO \$con = null)
     {
         \$this->getLevel();
 
@@ -520,7 +520,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO Connection to use.
      * @return array
      */
-    public function getDescendants(PropelPDO \$con = null)
+    public function getDescendants(?PropelPDO \$con = null)
     {
         \$this->getLevel();
 
@@ -588,7 +588,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con Connection to use.
      * @return bool
      */
-    public function hasParent(PropelPDO \$con = null)
+    public function hasParent(?PropelPDO \$con = null)
     {
         if (null === \$this->hasParentNode) {
             $peerClassname::hasParent(\$this, \$con);
@@ -625,7 +625,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con Connection to use.
      * @return bool
      */
-    public function hasPrevSibling(PropelPDO \$con = null)
+    public function hasPrevSibling(?PropelPDO \$con = null)
     {
         if (null === \$this->hasPrevSibling) {
             $peerClassname::hasPrevSibling(\$this, \$con);
@@ -646,7 +646,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con Connection to use.
      * @return bool
      */
-    public function hasNextSibling(PropelPDO \$con = null)
+    public function hasNextSibling(?PropelPDO \$con = null)
     {
         if (null === \$this->hasNextSibling) {
             $peerClassname::hasNextSibling(\$this, \$con);
@@ -667,7 +667,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con Connection to use.
      * @return mixed Propel object if exists else false
      */
-    public function retrieveParent(PropelPDO \$con = null)
+    public function retrieveParent(?PropelPDO \$con = null)
     {
         if (null === \$this->hasParentNode) {
             \$this->parentNode = $peerClassname::retrieveParent(\$this, \$con);
@@ -689,7 +689,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con Connection to use.
      * @return mixed Propel object if exists else false
      */
-    public function retrieveFirstChild(PropelPDO \$con = null)
+    public function retrieveFirstChild(?PropelPDO \$con = null)
     {
         if (\$this->hasChildren(\$con)) {
             if (is_array(\$this->_children)) {
@@ -714,7 +714,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con Connection to use.
      * @return mixed Propel object if exists else false
      */
-    public function retrieveLastChild(PropelPDO \$con = null)
+    public function retrieveLastChild(?PropelPDO \$con = null)
     {
         if (\$this->hasChildren(\$con)) {
             if (is_array(\$this->_children)) {
@@ -740,7 +740,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con Connection to use.
      * @return mixed Propel object if exists else false
      */
-    public function retrievePrevSibling(PropelPDO \$con = null)
+    public function retrievePrevSibling(?PropelPDO \$con = null)
     {
         if (\$this->hasPrevSibling(\$con)) {
             return \$this->prevSibling;
@@ -760,7 +760,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con Connection to use.
      * @return mixed Propel object if exists else false
      */
-    public function retrieveNextSibling(PropelPDO \$con = null)
+    public function retrieveNextSibling(?PropelPDO \$con = null)
     {
         if (\$this->hasNextSibling(\$con)) {
             return \$this->nextSibling;
@@ -784,7 +784,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @return                 $objectClassName The current object (for fluent API support)
      * @throws PropelException - if this object already exists
      */
-    public function insertAsFirstChildOf(NodeObject \$parent, PropelPDO \$con = null)
+    public function insertAsFirstChildOf(NodeObject \$parent, ?PropelPDO \$con = null)
     {
         if (!\$this->isNew()) {
             throw new PropelException(\"$objectClassName must be new.\");
@@ -809,7 +809,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @return                 $objectClassName The current object (for fluent API support)
      * @throws PropelException - if this object already exists
      */
-    public function insertAsLastChildOf(NodeObject \$parent, PropelPDO \$con = null)
+    public function insertAsLastChildOf(NodeObject \$parent, ?PropelPDO \$con = null)
     {
         if (!\$this->isNew()) {
             throw new PropelException(\"$objectClassName must be new.\");
@@ -834,7 +834,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @return                 $objectClassName The current object (for fluent API support)
      * @throws PropelException - if this object already exists
      */
-    public function insertAsPrevSiblingOf(NodeObject \$dest, PropelPDO \$con = null)
+    public function insertAsPrevSiblingOf(NodeObject \$dest, ?PropelPDO \$con = null)
     {
         if (!\$this->isNew()) {
             throw new PropelException(\"$objectClassName must be new.\");
@@ -859,7 +859,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @return                 $objectClassName The current object (for fluent API support)
      * @throws PropelException - if this object already exists
      */
-    public function insertAsNextSiblingOf(NodeObject \$dest, PropelPDO \$con = null)
+    public function insertAsNextSiblingOf(NodeObject \$dest, ?PropelPDO \$con = null)
     {
         if (!\$this->isNew()) {
             throw new PropelException(\"$objectClassName must be new.\");
@@ -883,7 +883,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con Connection to use.
      * @return   $objectClassName The current object (for fluent API support)
      */
-    public function moveToFirstChildOf(NodeObject \$parent, PropelPDO \$con = null)
+    public function moveToFirstChildOf(NodeObject \$parent, ?PropelPDO \$con = null)
     {
         if (\$this->isNew()) {
             throw new PropelException(\"$objectClassName must exist in tree.\");
@@ -907,7 +907,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con Connection to use.
      * @return   $objectClassName The current object (for fluent API support)
      */
-    public function moveToLastChildOf(NodeObject \$parent, PropelPDO \$con = null)
+    public function moveToLastChildOf(NodeObject \$parent, ?PropelPDO \$con = null)
     {
         if (\$this->isNew()) {
             throw new PropelException(\"$objectClassName must exist in tree.\");
@@ -931,7 +931,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con Connection to use.
      * @return   $objectClassName The current object (for fluent API support)
      */
-    public function moveToPrevSiblingOf(NodeObject \$dest, PropelPDO \$con = null)
+    public function moveToPrevSiblingOf(NodeObject \$dest, ?PropelPDO \$con = null)
     {
         if (\$this->isNew()) {
             throw new PropelException(\"$objectClassName must exist in tree.\");
@@ -955,7 +955,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con Connection to use.
      * @return   $objectClassName The current object (for fluent API support)
      */
-    public function moveToNextSiblingOf(NodeObject \$dest, PropelPDO \$con = null)
+    public function moveToNextSiblingOf(NodeObject \$dest, ?PropelPDO \$con = null)
     {
         if (\$this->isNew()) {
             throw new PropelException(\"$objectClassName must exist in tree.\");
@@ -979,7 +979,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getObjectBuilder
      * @param      PropelPDO \$con	Connection to use.
      * @return   $objectClassName The current object (for fluent API support)
      */
-    public function insertAsParentOf(NodeObject \$node, PropelPDO \$con = null)
+    public function insertAsParentOf(NodeObject \$node, ?PropelPDO \$con = null)
     {
         $peerClassname::insertAsParentOf(\$this, \$node, \$con);
 

--- a/generator/lib/builder/om/PHP5NestedSetPeerBuilder.php
+++ b/generator/lib/builder/om/PHP5NestedSetPeerBuilder.php
@@ -268,7 +268,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return   $objectClassname			Propel object for root node
      */
-    public static function retrieveRoot(\$scopeId = null, PropelPDO \$con = null)
+    public static function retrieveRoot(\$scopeId = null, ?PropelPDO \$con = null)
     {
         \$c = new Criteria($peerClassname::DATABASE_NAME);
 
@@ -296,7 +296,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return void
      */
-    public static function insertAsFirstChildOf(NodeObject \$child, NodeObject \$parent, PropelPDO \$con = null)
+    public static function insertAsFirstChildOf(NodeObject \$child, NodeObject \$parent, ?PropelPDO \$con = null)
     {
         // Update \$child node properties
         \$child->setLeftValue(\$parent->getLeftValue() + 1);
@@ -330,7 +330,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return void
      */
-    public static function insertAsLastChildOf(NodeObject \$child, NodeObject \$parent, PropelPDO \$con = null)
+    public static function insertAsLastChildOf(NodeObject \$child, NodeObject \$parent, ?PropelPDO \$con = null)
     {
         // Update \$child node properties
         \$child->setLeftValue(\$parent->getRightValue());
@@ -364,7 +364,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return void
      */
-    public static function insertAsPrevSiblingOf(NodeObject \$node, NodeObject \$sibling, PropelPDO \$con = null)
+    public static function insertAsPrevSiblingOf(NodeObject \$node, NodeObject \$sibling, ?PropelPDO \$con = null)
     {
         if (\$sibling->isRoot()) {
             throw new PropelException('Root nodes cannot have siblings');
@@ -401,7 +401,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return void
      */
-    public static function insertAsNextSiblingOf(NodeObject \$node, NodeObject \$sibling, PropelPDO \$con = null)
+    public static function insertAsNextSiblingOf(NodeObject \$node, NodeObject \$sibling, ?PropelPDO \$con = null)
     {
         if (\$sibling->isRoot()) {
             throw new PropelException('Root nodes cannot have siblings');
@@ -438,7 +438,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return void
      */
-    public static function insertAsParentOf(NodeObject \$parent, NodeObject \$node, PropelPDO \$con = null)
+    public static function insertAsParentOf(NodeObject \$parent, NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$sidv = null;
         if (self::SCOPE_COL) {
@@ -479,7 +479,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return void
      */
-    public static function insertRoot(NodeObject \$node, PropelPDO \$con = null)
+    public static function insertRoot(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$sidv = null;
         if (self::SCOPE_COL) {
@@ -506,7 +506,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return void
      */
-    public static function insertParent(NodeObject \$child, NodeObject \$parent, PropelPDO \$con = null)
+    public static function insertParent(NodeObject \$child, NodeObject \$parent, ?PropelPDO \$con = null)
     {
         self::insertAsParentOf(\$parent, \$child, \$con);
     }
@@ -523,7 +523,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return boolean Deletion status
      */
-    public static function deleteRoot(\$scopeId = null, PropelPDO \$con = null)
+    public static function deleteRoot(\$scopeId = null, ?PropelPDO \$con = null)
     {
         if (!self::SCOPE_COL) {
             \$scopeId = null;
@@ -550,7 +550,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return boolean Deletion status
      */
-    public static function deleteNode(NodeObject \$dest, PropelPDO \$con = null)
+    public static function deleteNode(NodeObject \$dest, ?PropelPDO \$con = null)
     {
         if (\$dest->getLeftValue() == 1) {
             // deleting root implies conditions (see deleteRoot() method)
@@ -583,7 +583,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return void
      */
-    public static function moveToFirstChildOf(NodeObject \$parent, NodeObject \$child, PropelPDO \$con = null)
+    public static function moveToFirstChildOf(NodeObject \$parent, NodeObject \$child, ?PropelPDO \$con = null)
     {
         if (\$parent->getScopeIdValue() != \$child->getScopeIdValue()) {
             throw new PropelException('Moving nodes across trees is not supported');
@@ -610,7 +610,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return void
      */
-    public static function moveToLastChildOf(NodeObject \$parent, NodeObject \$child, PropelPDO \$con = null)
+    public static function moveToLastChildOf(NodeObject \$parent, NodeObject \$child, ?PropelPDO \$con = null)
     {
         if (\$parent->getScopeIdValue() != \$child->getScopeIdValue()) {
             throw new PropelException('Moving nodes across trees is not supported');
@@ -637,7 +637,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return void
      */
-    public static function moveToPrevSiblingOf(NodeObject \$dest, NodeObject \$node, PropelPDO \$con = null)
+    public static function moveToPrevSiblingOf(NodeObject \$dest, NodeObject \$node, ?PropelPDO \$con = null)
     {
         if (\$dest->getScopeIdValue() != \$node->getScopeIdValue()) {
             throw new PropelException('Moving nodes across trees is not supported');
@@ -664,7 +664,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return void
      */
-    public static function moveToNextSiblingOf(NodeObject \$dest, NodeObject \$node, PropelPDO \$con = null)
+    public static function moveToNextSiblingOf(NodeObject \$dest, NodeObject \$node, ?PropelPDO \$con = null)
     {
         if (\$dest->getScopeIdValue() != \$node->getScopeIdValue()) {
             throw new PropelException('Moving nodes across trees is not supported');
@@ -691,7 +691,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return mixed Propel object if exists else false
      */
-    public static function retrieveFirstChild(NodeObject \$node, PropelPDO \$con = null)
+    public static function retrieveFirstChild(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$c = new Criteria($peerClassname::DATABASE_NAME);
         \$c->add(self::LEFT_COL, \$node->getLeftValue() + 1, Criteria::EQUAL);
@@ -716,7 +716,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return mixed Propel object if exists else false
      */
-    public static function retrieveLastChild(NodeObject \$node, PropelPDO \$con = null)
+    public static function retrieveLastChild(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$c = new Criteria($peerClassname::DATABASE_NAME);
         \$c->add(self::RIGHT_COL, \$node->getRightValue() - 1, Criteria::EQUAL);
@@ -741,7 +741,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return mixed Propel object if exists else null
      */
-    public static function retrievePrevSibling(NodeObject \$node, PropelPDO \$con = null)
+    public static function retrievePrevSibling(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$c = new Criteria($peerClassname::DATABASE_NAME);
         \$c->add(self::RIGHT_COL, \$node->getLeftValue() - 1, Criteria::EQUAL);
@@ -768,7 +768,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return mixed Propel object if exists else false
      */
-    public static function retrieveNextSibling(NodeObject \$node, PropelPDO \$con = null)
+    public static function retrieveNextSibling(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$c = new Criteria($peerClassname::DATABASE_NAME);
         \$c->add(self::LEFT_COL, \$node->getRightValue() + 1, Criteria::EQUAL);
@@ -792,7 +792,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      *
      * @param      PropelPDO \$con	Connection to use.
      */
-    public static function retrieveTree(\$scopeId = null, PropelPDO \$con = null)
+    public static function retrieveTree(\$scopeId = null, ?PropelPDO \$con = null)
     {
         \$c = new Criteria($peerClassname::DATABASE_NAME);
         \$c->addAscendingOrderByColumn(self::LEFT_COL);
@@ -835,7 +835,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param   $objectClassname \$node	Propel object for parent node
      * @param      PropelPDO \$con	Connection to use.
      */
-    public static function retrieveBranch(NodeObject \$node, PropelPDO \$con = null)
+    public static function retrieveBranch(NodeObject \$node, ?PropelPDO \$con = null)
     {
         return $peerClassname::retrieveDescendants(\$node, \$con);
     }
@@ -853,7 +853,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param   $objectClassname \$node	Propel object for parent node
      * @param      PropelPDO \$con	Connection to use.
      */
-    public static function retrieveChildren(NodeObject \$node, PropelPDO \$con = null)
+    public static function retrieveChildren(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$c = new Criteria($peerClassname::DATABASE_NAME);
         \$c->addAscendingOrderByColumn(self::LEFT_COL);
@@ -880,7 +880,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param   $objectClassname \$node	Propel object for parent node
      * @param      PropelPDO \$con	Connection to use.
      */
-    public static function retrieveDescendants(NodeObject \$node, PropelPDO \$con = null)
+    public static function retrieveDescendants(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$c = new Criteria($peerClassname::DATABASE_NAME);
         \$c->addAscendingOrderByColumn(self::LEFT_COL);
@@ -907,7 +907,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param   $objectClassname \$node	Propel object for src node
      * @param      PropelPDO \$con	Connection to use.
      */
-    public static function retrieveSiblings(NodeObject \$node, PropelPDO \$con = null)
+    public static function retrieveSiblings(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$parent = $peerClassname::retrieveParent(\$node, \$con);
         \$siblings = $peerClassname::retrieveChildren(\$parent, \$con);
@@ -929,7 +929,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return mixed Propel object if exists else null
      */
-    public static function retrieveParent(NodeObject \$node, PropelPDO \$con = null)
+    public static function retrieveParent(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$c = new Criteria($peerClassname::DATABASE_NAME);
         \$c1 = \$c->getNewCriterion(self::LEFT_COL, \$node->getLeftValue(), Criteria::LESS_THAN);
@@ -964,7 +964,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return int Level for the given node
      */
-    public static function getLevel(NodeObject \$node, PropelPDO \$con = null)
+    public static function getLevel(NodeObject \$node, ?PropelPDO \$con = null)
     {
         if (\$con === null) {
             \$con = Propel::getConnection($peerClassname::DATABASE_NAME, Propel::CONNECTION_READ);
@@ -1002,7 +1002,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return int Level for the given node
      */
-    public static function getNumberOfChildren(NodeObject \$node, PropelPDO \$con = null)
+    public static function getNumberOfChildren(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$children = $peerClassname::retrieveChildren(\$node);
 
@@ -1023,7 +1023,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return int Level for the given node
      */
-    public static function getNumberOfDescendants(NodeObject \$node, PropelPDO \$con = null)
+    public static function getNumberOfDescendants(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$right = \$node->getRightValue();
         \$left = \$node->getLeftValue();
@@ -1046,7 +1046,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con	Connection to use.
      * @return array Array in order of hierarchy
      */
-    public static function getPath(NodeObject \$node, PropelPDO \$con = null)
+    public static function getPath(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$criteria = new Criteria();
         if (self::SCOPE_COL) {
@@ -1072,7 +1072,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param       $objectClassname \$node	Propel object for src node
      * @return bool
      */
-    public static function isValid(NodeObject \$node = null)
+    public static function isValid(?NodeObject \$node = null)
     {
         if (is_object(\$node) && \$node->getRightValue() > \$node->getLeftValue()) {
             return true;
@@ -1194,7 +1194,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con		Connection to use.
      * @return bool
      */
-    public static function hasParent(NodeObject \$node, PropelPDO \$con = null)
+    public static function hasParent(NodeObject \$node, ?PropelPDO \$con = null)
     {
         return $peerClassname::isValid($peerClassname::retrieveParent(\$node, \$con));
     }
@@ -1213,7 +1213,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con		Connection to use.
      * @return bool
      */
-    public static function hasPrevSibling(NodeObject \$node, PropelPDO \$con = null)
+    public static function hasPrevSibling(NodeObject \$node, ?PropelPDO \$con = null)
     {
         return $peerClassname::isValid($peerClassname::retrievePrevSibling(\$node, \$con));
     }
@@ -1232,7 +1232,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con		Connection to use.
      * @return bool
      */
-    public static function hasNextSibling(NodeObject \$node, PropelPDO \$con = null)
+    public static function hasNextSibling(NodeObject \$node, ?PropelPDO \$con = null)
     {
         return $peerClassname::isValid($peerClassname::retrieveNextSibling(\$node, \$con));
     }
@@ -1268,7 +1268,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param   $objectClassname \$node		Propel object for source node
      * @param      PropelPDO \$con		Connection to use.
      */
-    public static function deleteDescendants(NodeObject \$node, PropelPDO \$con = null)
+    public static function deleteDescendants(NodeObject \$node, ?PropelPDO \$con = null)
     {
         \$left = \$node->getLeftValue();
         \$right = \$node->getRightValue();
@@ -1306,7 +1306,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con		Connection to use.
      * @return object Propel object for model
      */
-    public static function getNode(\$node, PropelPDO \$con = null)
+    public static function getNode(\$node, ?PropelPDO \$con = null)
     {
         if (is_object(\$node)) {
             return \$node;
@@ -1475,7 +1475,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      int \$delta	Value to be shifted by, can be negative
      * @param      PropelPDO \$con		Connection to use.
      */
-    protected static function shiftRParent(NodeObject \$node, \$delta, PropelPDO \$con = null)
+    protected static function shiftRParent(NodeObject \$node, \$delta, ?PropelPDO \$con = null)
     {
         if (\$node->hasParent(\$con)) {
             \$parent = \$node->retrieveParent();
@@ -1500,7 +1500,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      int \$delta	Value to be shifted by, can be negative
      * @param      PropelPDO \$con		Connection to use.
      */
-    protected static function updateLoadedNode(NodeObject \$node, \$delta, PropelPDO \$con = null)
+    protected static function updateLoadedNode(NodeObject \$node, \$delta, ?PropelPDO \$con = null)
     {
         if (Propel::isInstancePoolingEnabled()) {
             \$keys = array();
@@ -1582,7 +1582,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      int	\$destLeft Destination left value
      * @param      PropelPDO \$con		Connection to use.
      */
-    protected static function updateDBNode(NodeObject \$node, \$destLeft, PropelPDO \$con = null)
+    protected static function updateDBNode(NodeObject \$node, \$destLeft, ?PropelPDO \$con = null)
     {
         \$left = \$node->getLeftValue();
         \$right = \$node->getRightValue();
@@ -1616,7 +1616,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      int \$delta		Value to be shifted by, can be negative
      * @param      PropelPDO \$con		Connection to use.
      */
-    protected static function shiftRLValues(\$first, \$delta, PropelPDO \$con = null, \$scopeId = null)
+    protected static function shiftRLValues(\$first, \$delta, ?PropelPDO \$con = null, \$scopeId = null)
     {
         if (\$con === null) {
             \$con = Propel::getConnection($peerClassname::DATABASE_NAME, Propel::CONNECTION_WRITE);
@@ -1690,7 +1690,7 @@ abstract class " . $this->getClassname() . " extends " . $this->getPeerBuilder()
      * @param      PropelPDO \$con		Connection to use.
      * @return array Shifted L and R values
      */
-    protected static function shiftRLRange(\$first, \$last, \$delta, PropelPDO \$con = null, \$scopeId = null)
+    protected static function shiftRLRange(\$first, \$last, \$delta, ?PropelPDO \$con = null, \$scopeId = null)
     {
         if (\$con === null) {
             \$con = Propel::getConnection($peerClassname::DATABASE_NAME, Propel::CONNECTION_WRITE);

--- a/generator/lib/builder/om/PHP5NodeBuilder.php
+++ b/generator/lib/builder/om/PHP5NodeBuilder.php
@@ -375,7 +375,7 @@ abstract class " . $this->getClassname() . " implements IteratorAggregate {
      * @param      PropelPDO \$con     Connection to use if retrieving from database.
      * @return " . $this->getStubNodeBuilder()->getClassname() . "
      */
-    public function getChildNodeAt(\$i, \$querydb = false, PropelPDO \$con = null)
+    public function getChildNodeAt(\$i, \$querydb = false, ?PropelPDO \$con = null)
     {
         if (\$querydb &&
             !\$this->obj->isNew() &&
@@ -404,7 +404,7 @@ abstract class " . $this->getClassname() . " implements IteratorAggregate {
      * @param      PropelPDO \$con     Connection to use if retrieving from database.
      * @return " . $this->getStubNodeBuilder()->getClassname() . "
      */
-    public function getFirstChildNode(\$querydb = false, PropelPDO \$con = null)
+    public function getFirstChildNode(\$querydb = false, ?PropelPDO \$con = null)
     {
         return \$this->getChildNodeAt(1, \$querydb, \$con);
     }
@@ -423,7 +423,7 @@ abstract class " . $this->getClassname() . " implements IteratorAggregate {
      * @param      boolean   \$querydb True if child should be retrieved from database.
      * @param      PropelPDO \$con     Connection to use if retrieving from database.
      */
-    public function getLastChildNode(\$querydb = false, PropelPDO \$con = null)
+    public function getLastChildNode(\$querydb = false, ?PropelPDO \$con = null)
     {
         \$lastNode = null;
 
@@ -478,7 +478,7 @@ abstract class " . $this->getClassname() . " implements IteratorAggregate {
      * @param      PropelPDO \$con     Connection to use if retrieving from database.
      * @return " . $this->getStubNodeBuilder()->getClassname() . "
      */
-    public function getSiblingNode(\$prev = false, \$querydb = false, PropelPDO \$con = null)
+    public function getSiblingNode(\$prev = false, \$querydb = false, ?PropelPDO \$con = null)
     {
         \$nidx = \$this->getNodeIndex();
 
@@ -512,7 +512,7 @@ abstract class " . $this->getClassname() . " implements IteratorAggregate {
      * @param      PropelPDO \$con     Connection to use if retrieving from database.
      * @return " . $this->getStubNodeBuilder()->getClassname() . "
      */
-    public function getParentNode(\$querydb = true, PropelPDO \$con = null)
+    public function getParentNode(\$querydb = true, ?PropelPDO \$con = null)
     {
         if (\$querydb &&
             \$this->parentNode === null &&
@@ -549,7 +549,7 @@ abstract class " . $this->getClassname() . " implements IteratorAggregate {
      * @param      PropelPDO \$con     Connection to use if retrieving from database.
      * @return array
      */
-    public function getAncestors(\$querydb = false, PropelPDO \$con = null)
+    public function getAncestors(\$querydb = false, ?PropelPDO \$con = null)
     {
         \$ancestors = array();
         \$parentNode = \$this;
@@ -627,7 +627,7 @@ abstract class " . $this->getClassname() . " implements IteratorAggregate {
      * @param " . $this->getStubNodeBuilder()->getClassname() . " \$beforeNode Node to insert before.
      * @param      PropelPDO \$con Connection to use.
      */
-    public function addChildNode(\$node, \$beforeNode = null, PropelPDO \$con = null)
+    public function addChildNode(\$node, \$beforeNode = null, ?PropelPDO \$con = null)
     {
         if (\$this->obj->isNew() && !\$node->obj->isNew())
             throw new PropelException('Cannot add stored nodes to a new node.');
@@ -708,7 +708,7 @@ abstract class " . $this->getClassname() . " implements IteratorAggregate {
      * @param      PropelPDO \$con       Connection to use.
      * @throws PropelException
      */
-    public function moveChildNode(\$node, \$direction, PropelPDO \$con = null)
+    public function moveChildNode(\$node, \$direction, ?PropelPDO \$con = null)
     {
         throw new PropelException('moveChildNode() not implemented yet.');
     }
@@ -726,7 +726,7 @@ abstract class " . $this->getClassname() . " implements IteratorAggregate {
      * @param      boolean   \$recurse If true, descendants will be saved as well.
      * @param      PropelPDO \$con     Connection to use.
      */
-    public function save(\$recurse = false, PropelPDO \$con = null)
+    public function save(\$recurse = false, ?PropelPDO \$con = null)
     {
         if (\$this->obj->isDeleted())
             throw new PropelException('Cannot save deleted node.');
@@ -759,7 +759,7 @@ abstract class " . $this->getClassname() . " implements IteratorAggregate {
      * @return void
      * @throws PropelException
      */
-    public function delete(PropelPDO \$con = null)
+    public function delete(?PropelPDO \$con = null)
     {
         if (\$this->obj->isDeleted()) {
             throw new PropelException('This node has already been deleted.');

--- a/generator/lib/builder/om/PHP5NodePeerBuilder.php
+++ b/generator/lib/builder/om/PHP5NodePeerBuilder.php
@@ -191,7 +191,7 @@ abstract class " . $this->getClassname() . " {
      * @return                 $nodeObjectClassname
      * @throws PropelException
      */
-    public static function createNewRootNode(\$obj, PropelPDO \$con = null)
+    public static function createNewRootNode(\$obj, ?PropelPDO \$con = null)
     {
         if (\$con === null)
             \$con = Propel::getConnection($peerClassname::DATABASE_NAME, Propel::CONNECTION_WRITE);
@@ -236,7 +236,7 @@ abstract class " . $this->getClassname() . " {
      * @return                 $nodeObjectClassname
      * @throws PropelException
      */
-    public static function insertNewRootNode(\$obj, PropelPDO \$con = null)
+    public static function insertNewRootNode(\$obj, ?PropelPDO \$con = null)
     {
         if (\$con === null)
             \$con = Propel::getConnection($peerClassname::DATABASE_NAME, Propel::CONNECTION_WRITE);
@@ -293,7 +293,7 @@ abstract class " . $this->getClassname() . " {
      * @param      PropelPDO Connection to use.
      * @return array Array of root nodes.
      */
-    public static function retrieveNodes(\$criteria, \$ancestors = false, \$descendants = false, PropelPDO \$con = null)
+    public static function retrieveNodes(\$criteria, \$ancestors = false, \$descendants = false, ?PropelPDO \$con = null)
     {
         \$criteria = $nodePeerClassname::buildFamilyCriteria(\$criteria, \$ancestors, \$descendants);
         \$stmt = " . $this->getStubPeerBuilder()->getClassname() . "::doSelectStmt(\$criteria, \$con);
@@ -322,7 +322,7 @@ abstract class " . $this->getClassname() . " {
      * @param      PropelPDO Connection to use.
      * @return   $nodeObjectClassname
      */
-    public static function retrieveNodeByPK(\$pk, \$ancestors = false, \$descendants = false, PropelPDO \$con = null)
+    public static function retrieveNodeByPK(\$pk, \$ancestors = false, \$descendants = false, ?PropelPDO \$con = null)
     {
         throw new PropelException('retrieveNodeByPK() not implemented yet.');
     }
@@ -348,7 +348,7 @@ abstract class " . $this->getClassname() . " {
      * @param      PropelPDO Connection to use.
      * @return   $objectClassname
      */
-    public static function retrieveNodeByNP(\$np, \$ancestors = false, \$descendants = false, PropelPDO \$con = null)
+    public static function retrieveNodeByNP(\$np, \$ancestors = false, \$descendants = false, ?PropelPDO \$con = null)
     {
         \$criteria = new Criteria($peerClassname::DATABASE_NAME);
         \$criteria->add(self::NPATH_COLNAME, \$np, Criteria::EQUAL);
@@ -372,7 +372,7 @@ abstract class " . $this->getClassname() . " {
      * @param      PropelPDO Connection to use.
      * @return " . $this->getStubNodeBuilder()->getClassname() . "
      */
-    public static function retrieveRootNode(\$descendants = false, PropelPDO \$con = null)
+    public static function retrieveRootNode(\$descendants = false, ?PropelPDO \$con = null)
     {
         return self::retrieveNodeByNP('1', false, \$descendants, \$con);
     }
@@ -406,7 +406,7 @@ abstract class " . $this->getClassname() . " {
      *       seem to be standardized (i.e. mssql), so maybe it needs to be moved
      *       to DBAdapter.
      */
-    public static function moveNodeSubTree(\$srcPath, \$dstPath, PropelPDO \$con = null)
+    public static function moveNodeSubTree(\$srcPath, \$dstPath, ?PropelPDO \$con = null)
     {
         if (substr(\$dstPath, 0, strlen(\$srcPath)) == \$srcPath)
             throw new PropelException('Cannot move a node subtree within itself.');
@@ -476,7 +476,7 @@ abstract class " . $this->getClassname() . " {
      * @throws PropelException
      * @todo       This is currently broken for simulated 'onCascadeDelete's.
      */
-    public static function deleteNodeSubTree(\$nodePath, PropelPDO \$con = null)
+    public static function deleteNodeSubTree(\$nodePath, ?PropelPDO \$con = null)
     {
         if (\$con === null)
             \$con = Propel::getConnection($peerClassname::DATABASE_NAME, Propel::CONNECTION_WRITE);

--- a/generator/lib/builder/om/PHP5ObjectBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectBuilder.php
@@ -1017,7 +1017,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
         $script .= "
         }
 
-        if (strpos(\$format, '%') !== false) {            
+        if (strpos(\$format, '%') !== false) {
             trigger_deprecation('dayspring-tech/propel1', '1.9', 'Using strftime style \"%\" formatting is deprecated. PHP 8.1 deprecated strftime().');
             return strftime(\$format, \$dt->format('U'));
         }
@@ -1144,7 +1144,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * " . $col->getDescription();
         if ($col->isLazyLoad()) {
             $script .= "
-     * @param PropelPDO \$con An optional PropelPDO connection to use for fetching this lazy-loaded column.";
+     * @param ?PropelPDO \$con An optional PropelPDO connection to use for fetching this lazy-loaded column.";
         }
         $script .= "
      * @return "               . $col->getPhpType() . "
@@ -1203,14 +1203,14 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * " . $col->getDescription();
         if ($col->isLazyLoad()) {
             $script .= "
-     * @param PropelPDO \$con An optional PropelPDO connection to use for fetching this lazy-loaded column.";
+     * @param ?PropelPDO \$con An optional PropelPDO connection to use for fetching this lazy-loaded column.";
         }
         $script .= "
      * @return boolean
      */
     $visibility function has$singularPhpName(\$value";
         if ($col->isLazyLoad()) {
-            $script .= ", PropelPDO \$con = null";
+            $script .= ", ?PropelPDO \$con = null";
         }
         $script .= ")
     {
@@ -1257,7 +1257,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * " . $col->getDescription();
         if ($col->isLazyLoad()) {
             $script .= "
-     * @param PropelPDO \$con An optional PropelPDO connection to use for fetching this lazy-loaded column.";
+     * @param ?PropelPDO \$con An optional PropelPDO connection to use for fetching this lazy-loaded column.";
         }
         $script .= "
      * @return " . $col->getPhpType() . "
@@ -1280,7 +1280,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
         $script .= "
     " . $visibility . " function get$cfc(";
         if ($col->isLazyLoad()) {
-            $script .= "PropelPDO \$con = null";
+            $script .= "?PropelPDO \$con = null";
         }
         $script .= ")
     {";
@@ -1376,7 +1376,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
     {
         $cfc = $col->getPhpName();
         $script .= "
-    protected function load$cfc(PropelPDO \$con = null)
+    protected function load$cfc(?PropelPDO \$con = null)
     {";
     }
 
@@ -1807,14 +1807,14 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * " . $col->getDescription();
         if ($col->isLazyLoad()) {
             $script .= "
-     * @param PropelPDO \$con An optional PropelPDO connection to use for fetching this lazy-loaded column.";
+     * @param ?PropelPDO \$con An optional PropelPDO connection to use for fetching this lazy-loaded column.";
         }
         $script .= "
      * @return " . $this->getObjectClassname() . " The current object (for fluent API support)
      */
     $visibility function add$singularPhpName(\$value";
         if ($col->isLazyLoad()) {
-            $script .= ", PropelPDO \$con = null";
+            $script .= ", ?PropelPDO \$con = null";
         }
         $script .= ")
     {
@@ -1850,14 +1850,14 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * " . $col->getDescription();
         if ($col->isLazyLoad()) {
             $script .= "
-     * @param PropelPDO \$con An optional PropelPDO connection to use for fetching this lazy-loaded column.";
+     * @param ?PropelPDO \$con An optional PropelPDO connection to use for fetching this lazy-loaded column.";
         }
         $script .= "
      * @return " . $this->getObjectClassname() . " The current object (for fluent API support)
      */
     $visibility function remove$singularPhpName(\$value";
         if ($col->isLazyLoad()) {
-            $script .= ", PropelPDO \$con = null";
+            $script .= ", ?PropelPDO \$con = null";
         }
         // we want to reindex the array, so array_ functions are not the best choice
         $script .= ")
@@ -2827,7 +2827,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
     protected function addDeleteOpen(&$script)
     {
         $script .= "
-    public function delete(PropelPDO \$con = null)
+    public function delete(?PropelPDO \$con = null)
     {";
     }
 
@@ -2922,7 +2922,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * @return void
      * @throws PropelException - if this object is deleted, unsaved or doesn't have pk match in db
      */
-    public function reload(\$deep = false, PropelPDO \$con = null)
+    public function reload(\$deep = false, ?PropelPDO \$con = null)
     {
         if (\$this->isDeleted()) {
             throw new PropelException(\"Cannot reload a deleted object.\");
@@ -3393,11 +3393,11 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
     /**
      * Declares an association between this object and a $className object.
      *
-     * @param                  $className \$v
+     * @param                  ?$className \$v
      * @return "               . $this->getObjectClassname() . " The current object (for fluent API support)
      * @throws PropelException
      */
-    public function set" . $this->getFKPhpNameAffix($fk, $plural = false) . "($className \$v = null)
+    public function set" . $this->getFKPhpNameAffix($fk, $plural = false) . "(?$className \$v = null)
     {";
         foreach ($fk->getLocalColumns() as $columnName) {
             $column = $table->getColumn($columnName);
@@ -3504,7 +3504,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * @return $className The associated $className object.
      * @throws PropelException
      */
-    public function get" . $this->getFKPhpNameAffix($fk, $plural = false) . "(PropelPDO \$con = null, \$doQuery = true)
+    public function get" . $this->getFKPhpNameAffix($fk, $plural = false) . "(?PropelPDO \$con = null, \$doQuery = true)
     {";
         $script .= "
         if (\$this->$varName === null && ($conditional) && \$doQuery) {";
@@ -3934,7 +3934,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * @return int             Count of related $className objects.
      * @throws PropelException
      */
-    public function count$relCol(Criteria \$criteria = null, \$distinct = false, PropelPDO \$con = null)
+    public function count$relCol(?Criteria \$criteria = null, \$distinct = false, ?PropelPDO \$con = null)
     {
         \$partial = \$this->{$collName}Partial && !\$this->isNew();
         if (null === \$this->$collName || null !== \$criteria || \$partial) {
@@ -3994,7 +3994,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * @return PropelObjectCollection|{$className}[] List of $className objects
      * @throws PropelException
      */
-    public function get$relCol(\$criteria = null, PropelPDO \$con = null)
+    public function get$relCol(\$criteria = null, ?PropelPDO \$con = null)
     {
         \$partial = \$this->{$collName}Partial && !\$this->isNew();
         if (null === \$this->$collName || null !== \$criteria  || \$partial) {
@@ -4063,7 +4063,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * @param PropelPDO \$con Optional connection object
      * @return " . $this->getObjectClassname() . " The current object (for fluent API support)
      */
-    public function set{$relatedName}(PropelCollection \${$inputCollection}, PropelPDO \$con = null)
+    public function set{$relatedName}(PropelCollection \${$inputCollection}, ?PropelPDO \$con = null)
     {
         \${$inputCollection}ToDelete = \$this->get{$relatedName}(new Criteria(), \$con)->diff(\${$inputCollection});
 
@@ -4200,7 +4200,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * @return $className
      * @throws PropelException
      */
-    public function get" . $this->getRefFKPhpNameAffix($refFK, $plural = false) . "(PropelPDO \$con = null)
+    public function get" . $this->getRefFKPhpNameAffix($refFK, $plural = false) . "(?PropelPDO \$con = null)
     {
 ";
         $script .= "
@@ -4237,7 +4237,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * @return "               . $this->getObjectClassname() . " The current object (for fluent API support)
      * @throws PropelException
      */
-    public function set" . $this->getRefFKPhpNameAffix($refFK, $plural = false) . "($className \$v = null)
+    public function set" . $this->getRefFKPhpNameAffix($refFK, $plural = false) . "(?$className \$v = null)
     {
         \$this->$varName = \$v;
 
@@ -4462,7 +4462,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      *
      * @return PropelObjectCollection|{$relatedObjectClassName}[] List of {$relatedObjectClassName} objects
      */
-    public function get{$relatedName}(\$criteria = null, PropelPDO \$con = null)
+    public function get{$relatedName}(\$criteria = null, ?PropelPDO \$con = null)
     {
         if (null === \$this->$collName || null !== \$criteria) {
             if (\$this->isNew() && null === \$this->$collName) {
@@ -4506,7 +4506,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      * @param PropelPDO \$con Optional connection object
      * @return " . $this->getObjectClassname() . " The current object (for fluent API support)
      */
-    public function set{$relatedNamePlural}(PropelCollection \${$inputCollection}, PropelPDO \$con = null)
+    public function set{$relatedNamePlural}(PropelCollection \${$inputCollection}, ?PropelPDO \$con = null)
     {
         \$this->clear{$relatedNamePlural}();
         \$current{$relatedNamePlural} = \$this->get{$relatedNamePlural}(null, \$con);
@@ -4545,7 +4545,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
      *
      * @return int the number of related $relatedObjectClassName objects
      */
-    public function count{$relatedName}(\$criteria = null, \$distinct = false, PropelPDO \$con = null)
+    public function count{$relatedName}(\$criteria = null, \$distinct = false, ?PropelPDO \$con = null)
     {
         if (null === \$this->$collName || null !== \$criteria) {
             if (\$this->isNew() && null === \$this->$collName) {
@@ -5218,7 +5218,7 @@ abstract class " . $this->getClassname() . " extends " . $parentClass . " ";
         $reloadOnUpdate = $table->isReloadOnUpdate();
         $reloadOnInsert = $table->isReloadOnInsert();
         $script .= "
-    public function save(PropelPDO \$con = null" . ($reloadOnUpdate || $reloadOnInsert ? ", \$skipReload = false" : "") . ")
+    public function save(?PropelPDO \$con = null" . ($reloadOnUpdate || $reloadOnInsert ? ", \$skipReload = false" : "") . ")
     {";
     }
 

--- a/generator/lib/builder/om/PHP5ObjectNoCollectionBuilder.php
+++ b/generator/lib/builder/om/PHP5ObjectNoCollectionBuilder.php
@@ -87,7 +87,7 @@ class PHP5ObjectNoCollectionBuilder extends PHP5ObjectBuilder
     {
         $cfc = $col->getPhpName();
         $script .= "
-    protected function load$cfc(PropelPDO \$con = null)
+    protected function load$cfc(?PropelPDO \$con = null)
     {";
     }
 
@@ -397,7 +397,7 @@ class PHP5ObjectNoCollectionBuilder extends PHP5ObjectBuilder
      * @return void
      * @throws PropelException - if this object is deleted, unsaved or doesn't have pk match in db
      */
-    public function reload(\$deep = false, PropelPDO \$con = null)
+    public function reload(\$deep = false, ?PropelPDO \$con = null)
     {
         if (\$this->isDeleted()) {
             throw new PropelException(\"Cannot reload a deleted object.\");
@@ -542,7 +542,7 @@ class PHP5ObjectNoCollectionBuilder extends PHP5ObjectBuilder
      * @return                 $className The associated $className object.
      * @throws PropelException
      */
-    public function get" . $this->getFKPhpNameAffix($fk, $plural = false) . "(PropelPDO \$con = null)
+    public function get" . $this->getFKPhpNameAffix($fk, $plural = false) . "(?PropelPDO \$con = null)
     {";
         $script .= "
         if (\$this->$varName === null && ($conditional)) {";
@@ -792,7 +792,7 @@ class PHP5ObjectNoCollectionBuilder extends PHP5ObjectBuilder
      * @return int             Count of related $className objects.
      * @throws PropelException
      */
-    public function count$relCol(Criteria \$criteria = null, \$distinct = false, PropelPDO \$con = null)
+    public function count$relCol(?Criteria \$criteria = null, \$distinct = false, ?PropelPDO \$con = null)
     {";
 
         $script .= "
@@ -894,7 +894,7 @@ class PHP5ObjectNoCollectionBuilder extends PHP5ObjectBuilder
      * @return array           {$className}[]
      * @throws PropelException
      */
-    public function get$relCol(\$criteria = null, PropelPDO \$con = null)
+    public function get$relCol(\$criteria = null, ?PropelPDO \$con = null)
     {";
 
         $script .= "
@@ -983,7 +983,7 @@ class PHP5ObjectNoCollectionBuilder extends PHP5ObjectBuilder
      * @return                 $className
      * @throws PropelException
      */
-    public function get" . $this->getRefFKPhpNameAffix($refFK, $plural = false) . "(PropelPDO \$con = null)
+    public function get" . $this->getRefFKPhpNameAffix($refFK, $plural = false) . "(?PropelPDO \$con = null)
     {
 ";
         $script .= "

--- a/generator/lib/builder/om/PHP5PeerBuilder.php
+++ b/generator/lib/builder/om/PHP5PeerBuilder.php
@@ -735,7 +735,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @param      PropelPDO \$con
      * @return int Number of matching rows.
      */
-    public static function doCount(Criteria \$criteria, \$distinct = false, PropelPDO \$con = null)
+    public static function doCount(Criteria \$criteria, \$distinct = false, ?PropelPDO \$con = null)
     {
         // we may modify criteria, so copy it first
         \$criteria = clone \$criteria;
@@ -795,7 +795,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @throws PropelException Any exceptions caught during processing will be
      *		 rethrown wrapped into a PropelException.
      */
-    public static function doSelectOne(Criteria \$criteria, PropelPDO \$con = null)
+    public static function doSelectOne(Criteria \$criteria, ?PropelPDO \$con = null)
     {
         \$critcopy = clone \$criteria;
         \$critcopy->setLimit(1);
@@ -825,7 +825,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @throws PropelException Any exceptions caught during processing will be
      *		 rethrown wrapped into a PropelException.
      */
-    public static function doSelect(Criteria \$criteria, PropelPDO \$con = null)
+    public static function doSelect(Criteria \$criteria, ?PropelPDO \$con = null)
     {
         return " . $this->getPeerClassname() . "::populateObjects(" . $this->getPeerClassname() . "::doSelectStmt(\$criteria, \$con));
     }";
@@ -853,7 +853,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @return PDOStatement The executed PDOStatement object.
      * @see        " . $this->basePeerClassname . "::doSelect()
      */
-    public static function doSelectStmt(Criteria \$criteria, PropelPDO \$con = null)
+    public static function doSelectStmt(Criteria \$criteria, ?PropelPDO \$con = null)
     {
         if (\$con === null) {
             \$con = Propel::getConnection(" . $this->getPeerClassname() . "::DATABASE_NAME, Propel::CONNECTION_READ);
@@ -1452,7 +1452,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @throws PropelException Any exceptions caught during processing will be
      *		 rethrown wrapped into a PropelException.
      */
-    public static function doInsert(\$values, PropelPDO \$con = null)
+    public static function doInsert(\$values, ?PropelPDO \$con = null)
     {
         if (\$con === null) {
             \$con = Propel::getConnection(" . $this->getPeerClassname() . "::DATABASE_NAME, Propel::CONNECTION_WRITE);
@@ -1527,7 +1527,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @throws PropelException Any exceptions caught during processing will be
      *		 rethrown wrapped into a PropelException.
      */
-    public static function doUpdate(\$values, PropelPDO \$con = null)
+    public static function doUpdate(\$values, ?PropelPDO \$con = null)
     {
         if (\$con === null) {
             \$con = Propel::getConnection(" . $this->getPeerClassname() . "::DATABASE_NAME, Propel::CONNECTION_WRITE);
@@ -1582,7 +1582,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @return int             The number of affected rows (if supported by underlying database driver).
      * @throws PropelException
      */
-    public static function doDeleteAll(PropelPDO \$con = null)
+    public static function doDeleteAll(?PropelPDO \$con = null)
     {
         if (\$con === null) {
             \$con = Propel::getConnection(" . $this->getPeerClassname() . "::DATABASE_NAME, Propel::CONNECTION_WRITE);
@@ -1639,7 +1639,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @throws PropelException Any exceptions caught during processing will be
      *		 rethrown wrapped into a PropelException.
      */
-     public static function doDelete(\$values, PropelPDO \$con = null)
+     public static function doDelete(\$values, ?PropelPDO \$con = null)
      {
         if (\$con === null) {
             \$con = Propel::getConnection(" . $this->getPeerClassname() . "::DATABASE_NAME, Propel::CONNECTION_WRITE);
@@ -2017,7 +2017,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @param      PropelPDO \$con the connection to use
      * @return " . $this->getObjectClassname() . "
      */
-    public static function " . $this->getRetrieveMethodName() . "(\$pk, PropelPDO \$con = null)
+    public static function " . $this->getRetrieveMethodName() . "(\$pk, ?PropelPDO \$con = null)
     {
 
         if (null !== (\$obj = " . $this->getPeerClassname() . "::getInstanceFromPool(" . $this->getInstancePoolKeySnippet('$pk') . "))) {
@@ -2056,7 +2056,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @throws PropelException Any exceptions caught during processing will be
      *		 rethrown wrapped into a PropelException.
      */
-    public static function " . $this->getRetrieveMethodName() . "s(\$pks, PropelPDO \$con = null)
+    public static function " . $this->getRetrieveMethodName() . "s(\$pks, ?PropelPDO \$con = null)
     {
         if (\$con === null) {
             \$con = Propel::getConnection(" . $this->getPeerClassname() . "::DATABASE_NAME, Propel::CONNECTION_READ);
@@ -2110,7 +2110,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
 
         $script .= implode(', ', $php);
 
-        $script .= ", PropelPDO \$con = null) {
+        $script .= ", ?PropelPDO \$con = null) {
         \$_instancePoolKey = " . $this->getInstancePoolKeySnippet($php) . ";";
         $script .= "
          if (null !== (\$obj = " . $this->getPeerClassname() . "::getInstanceFromPool(\$_instancePoolKey))) {
@@ -2420,7 +2420,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @param      String    \$join_behavior the type of joins to use, defaults to $join_behavior
      * @return int Number of matching rows.
      */
-    public static function doCountJoin" . $thisTableObjectBuilder->getFKPhpNameAffix($fk, $plural = false) . "(Criteria \$criteria, \$distinct = false, PropelPDO \$con = null, \$join_behavior = $join_behavior)
+    public static function doCountJoin" . $thisTableObjectBuilder->getFKPhpNameAffix($fk, $plural = false) . "(Criteria \$criteria, \$distinct = false, ?PropelPDO \$con = null, \$join_behavior = $join_behavior)
     {
         // we're going to modify criteria, so copy it first
         \$criteria = clone \$criteria;
@@ -2662,7 +2662,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @param      String    \$join_behavior the type of joins to use, defaults to $join_behavior
      * @return int Number of matching rows.
      */
-    public static function doCountJoinAll(Criteria \$criteria, \$distinct = false, PropelPDO \$con = null, \$join_behavior = $join_behavior)
+    public static function doCountJoinAll(Criteria \$criteria, \$distinct = false, ?PropelPDO \$con = null, \$join_behavior = $join_behavior)
     {
         // we're going to modify criteria, so copy it first
         \$criteria = clone \$criteria;
@@ -2948,7 +2948,7 @@ abstract class " . $this->getClassname() . $extendingPeerClass . "
      * @param      String    \$join_behavior the type of joins to use, defaults to $join_behavior
      * @return int Number of matching rows.
      */
-    public static function doCountJoinAllExcept" . $thisTableObjectBuilder->getFKPhpNameAffix($fk, $plural = false) . "(Criteria \$criteria, \$distinct = false, PropelPDO \$con = null, \$join_behavior = $join_behavior)
+    public static function doCountJoinAllExcept" . $thisTableObjectBuilder->getFKPhpNameAffix($fk, $plural = false) . "(Criteria \$criteria, \$distinct = false, ?PropelPDO \$con = null, \$join_behavior = $join_behavior)
     {
         // we're going to modify criteria, so copy it first
         \$criteria = clone \$criteria;

--- a/generator/lib/builder/om/QueryBuilder.php
+++ b/generator/lib/builder/om/QueryBuilder.php
@@ -140,8 +140,8 @@ class QueryBuilder extends OMBuilder
 
         // override the signature of ModelCriteria::findOne() to specify the class of the returned object, for IDE completion
         $script .= "
- * @method $modelClass findOne(PropelPDO \$con = null) Return the first $modelClass matching the query
- * @method $modelClass findOneOrCreate(PropelPDO \$con = null) Return the first $modelClass matching the query, or a new $modelClass object populated from the query conditions when no match is found
+ * @method $modelClass findOne(?PropelPDO \$con = null) Return the first $modelClass matching the query
+ * @method $modelClass findOneOrCreate(?PropelPDO \$con = null) Return the first $modelClass matching the query, or a new $modelClass object populated from the query conditions when no match is found
  *";
 
         // magic findBy() methods, for IDE completion

--- a/generator/lib/builder/util/XmlToAppData.php
+++ b/generator/lib/builder/util/XmlToAppData.php
@@ -61,7 +61,7 @@ class XmlToAppData
      * @param string                  $defaultPackage  the default PHP package used for the om
      * @param string                  $encoding        The database encoding.
      */
-    public function __construct(PropelPlatformInterface $defaultPlatform = null, $defaultPackage = null, $encoding = 'iso-8859-1')
+    public function __construct(?PropelPlatformInterface $defaultPlatform = null, $defaultPackage = null, $encoding = 'iso-8859-1')
     {
         $this->app = new AppData($defaultPlatform);
         $this->defaultPackage = $defaultPackage;

--- a/generator/lib/config/GeneratorConfig.php
+++ b/generator/lib/config/GeneratorConfig.php
@@ -160,7 +160,7 @@ class GeneratorConfig implements GeneratorConfigInterface
      * @return Platform
      * @throws BuildException
      */
-    public function getConfiguredPlatform(PDO $con = null, $database = null)
+    public function getConfiguredPlatform(?PDO $con = null, $database = null)
     {
         $buildConnection = $this->getBuildConnection($database);
         //First try to load platform from the user provided build properties
@@ -197,7 +197,7 @@ class GeneratorConfig implements GeneratorConfigInterface
      * @return SchemaParser
      * @throws BuildException
      */
-    public function getConfiguredSchemaParser(PDO $con = null)
+    public function getConfiguredSchemaParser(?PDO $con = null)
     {
         $clazz = $this->getClassname("reverseParserClass");
         $parser = new $clazz();

--- a/generator/lib/config/GeneratorConfigInterface.php
+++ b/generator/lib/config/GeneratorConfigInterface.php
@@ -50,7 +50,7 @@ interface GeneratorConfigInterface
     /**
      * Creates and configures a new Platform class.
      */
-    public function getConfiguredPlatform(PDO $con = null, $database = null);
+    public function getConfiguredPlatform(?PDO $con = null, $database = null);
 
     /**
      * Gets a configured behavior class

--- a/generator/lib/config/QuickGeneratorConfig.php
+++ b/generator/lib/config/QuickGeneratorConfig.php
@@ -43,7 +43,7 @@ class QuickGeneratorConfig implements GeneratorConfigInterface
 
     private $configuredPlatform = null;
 
-    public function __construct(PropelPlatformInterface $platform = null)
+    public function __construct(?PropelPlatformInterface $platform = null)
     {
         $this->configuredPlatform = $platform;
         $this->setBuildProperties($this->parsePseudoIniFile(dirname(__FILE__) . '/../../default.properties'));
@@ -160,7 +160,7 @@ class QuickGeneratorConfig implements GeneratorConfigInterface
     /**
      * {@inheritdoc}
      */
-    public function getConfiguredPlatform(PDO $con = null, $database = null)
+    public function getConfiguredPlatform(?PDO $con = null, $database = null)
     {
         if (null === $this->configuredPlatform) {
             return new SqlitePlatform($con);

--- a/generator/lib/model/AppData.php
+++ b/generator/lib/model/AppData.php
@@ -62,7 +62,7 @@ class AppData
      *
      * @param PropelPlatformInterface $defaultPlatform The default platform object to use for any databases added to this application model.
      */
-    public function __construct(PropelPlatformInterface $defaultPlatform = null)
+    public function __construct(?PropelPlatformInterface $defaultPlatform = null)
     {
         if (null !== $defaultPlatform) {
             $this->platform = $defaultPlatform;

--- a/generator/lib/model/Column.php
+++ b/generator/lib/model/Column.php
@@ -233,7 +233,7 @@ class Column extends XMLElement
 
             if ($this->getAttribute('valueSet', null) !== null) {
                 if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
-                    $valueSet = str_getcsv($this->getAttribute("valueSet"));
+                    $valueSet = str_getcsv($this->getAttribute("valueSet"), ",", "\"", "\\");
                 } else {
                     // unfortunately, no good fallback for PHP 5.2
                     $valueSet = explode(',', $this->getAttribute("valueSet"));
@@ -242,7 +242,7 @@ class Column extends XMLElement
                 $this->valueSet = $valueSet;
             } elseif (preg_match('/enum\((.*?)\)/i', $this->getAttribute('sqlType', ''), $matches)) {
                 if (version_compare(PHP_VERSION, '5.3.0', '>=')) {
-                    $valueSet = str_getcsv($matches['1'], ',', '\'');
+                    $valueSet = str_getcsv($matches['1'], ',', '\'', "\\");
                 } else {
                     // unfortunately, no good fallback for PHP 5.2
                     $valueSet = array();

--- a/generator/lib/model/Column.php
+++ b/generator/lib/model/Column.php
@@ -915,7 +915,7 @@ class Column extends XMLElement
         return $this->getType();
     }
 
-    public function isDefaultSqlType(PropelPlatformInterface $platform = null): bool
+    public function isDefaultSqlType(?PropelPlatformInterface $platform = null): bool
     {
         if (null === $this->domain || null === $this->domain->getSqlType() || null === $platform) {
             return true;

--- a/generator/lib/model/Domain.php
+++ b/generator/lib/model/Domain.php
@@ -306,7 +306,7 @@ class Domain extends XMLElement
      *
      * @param ColumnDefaultValue $value The default value object
      */
-    public function replaceDefaultValue(ColumnDefaultValue $value = null)
+    public function replaceDefaultValue(?ColumnDefaultValue $value = null)
     {
         if ($value !== null) {
             $this->defaultValue = $value;

--- a/generator/lib/platform/DefaultPlatform.php
+++ b/generator/lib/platform/DefaultPlatform.php
@@ -45,7 +45,7 @@ class DefaultPlatform implements PropelPlatformInterface
      *
      * @param PDO $con Optional database connection to use in this platform.
      */
-    public function __construct(PDO $con = null)
+    public function __construct(?PDO $con = null)
     {
         if ($con) {
             $this->setConnection($con);
@@ -58,7 +58,7 @@ class DefaultPlatform implements PropelPlatformInterface
      *
      * @param PDO $con Database connection to use in this platform.
      */
-    public function setConnection(PDO $con = null)
+    public function setConnection(?PDO $con = null)
     {
         $this->con = $con;
     }

--- a/generator/lib/platform/PropelPlatformInterface.php
+++ b/generator/lib/platform/PropelPlatformInterface.php
@@ -39,7 +39,7 @@ interface PropelPlatformInterface
      *
      * @param PDO $con The database connection to use in this Platform class.
      */
-    public function setConnection(PDO $con = null);
+    public function setConnection(?PDO $con = null);
 
     /**
      * Returns the database connection to use for this Platform class.

--- a/generator/lib/reverse/BaseSchemaParser.php
+++ b/generator/lib/reverse/BaseSchemaParser.php
@@ -67,7 +67,7 @@ abstract class BaseSchemaParser implements SchemaParser
     /**
      * @param PDO $dbh Optional database connection
      */
-    public function __construct(PDO $dbh = null)
+    public function __construct(?PDO $dbh = null)
     {
         if ($dbh) {
             $this->setConnection($dbh);

--- a/generator/lib/reverse/SchemaParser.php
+++ b/generator/lib/reverse/SchemaParser.php
@@ -63,5 +63,5 @@ interface SchemaParser
      *
      * @return int number of generated tables
      */
-    public function parse(Database $database, Task $task = null);
+    public function parse(Database $database, ?Task $task = null);
 }

--- a/generator/lib/reverse/mssql/MssqlSchemaParser.php
+++ b/generator/lib/reverse/mssql/MssqlSchemaParser.php
@@ -74,7 +74,7 @@ class MssqlSchemaParser extends BaseSchemaParser
     /**
      *
      */
-    public function parse(Database $database, Task $task = null)
+    public function parse(Database $database, ?Task $task = null)
     {
         $stmt = $this->dbh->query("SELECT TABLE_NAME FROM INFORMATION_SCHEMA.TABLES WHERE TABLE_TYPE = 'BASE TABLE' AND TABLE_NAME <> 'dtproperties'");
 

--- a/generator/lib/reverse/mysql/MysqlSchemaParser.php
+++ b/generator/lib/reverse/mysql/MysqlSchemaParser.php
@@ -82,7 +82,7 @@ class MysqlSchemaParser extends BaseSchemaParser
     /**
      *
      */
-    public function parse(Database $database, Task $task = null): int
+    public function parse(Database $database, ?Task $task = null): int
     {
         $this->addVendorInfo = $this->getGeneratorConfig()->getBuildProperty('addVendorInfo');
 

--- a/generator/lib/reverse/oracle/OracleSchemaParser.php
+++ b/generator/lib/reverse/oracle/OracleSchemaParser.php
@@ -73,7 +73,7 @@ class OracleSchemaParser extends BaseSchemaParser
      *
      * @return int
      */
-    public function parse(Database $database, Task $task = null): int
+    public function parse(Database $database, ?Task $task = null): int
     {
         $tables = array();
         $stmt = $this->dbh->query("SELECT OBJECT_NAME FROM USER_OBJECTS WHERE OBJECT_TYPE = 'TABLE'");

--- a/generator/lib/reverse/pgsql/PgsqlSchemaParser.php
+++ b/generator/lib/reverse/pgsql/PgsqlSchemaParser.php
@@ -74,7 +74,7 @@ class PgsqlSchemaParser extends BaseSchemaParser
     /**
      *
      */
-    public function parse(Database $database, Task $task = null): int
+    public function parse(Database $database, ?Task $task = null): int
     {
         $stmt = $this->dbh->query("SELECT version() as ver");
         $nativeVersion = $stmt->fetchColumn();

--- a/generator/lib/reverse/sqlite/SqliteSchemaParser.php
+++ b/generator/lib/reverse/sqlite/SqliteSchemaParser.php
@@ -72,7 +72,7 @@ class SqliteSchemaParser extends BaseSchemaParser
     /**
      *
      */
-    public function parse(Database $database, Task $task = null): int
+    public function parse(Database $database, ?Task $task = null): int
     {
         $stmt = $this->dbh->query("SELECT name FROM sqlite_master WHERE type='table' UNION ALL SELECT name FROM sqlite_temp_master WHERE type='table' ORDER BY name;");
 

--- a/generator/lib/util/PropelQuickBuilder.php
+++ b/generator/lib/util/PropelQuickBuilder.php
@@ -84,7 +84,7 @@ class PropelQuickBuilder
         return $builder->build($dsn, $user, $pass, $adapter);
     }
 
-    public function build($dsn = null, $user = null, $pass = null, $adapter = null, array $classTargets = null)
+    public function build($dsn = null, $user = null, $pass = null, $adapter = null, ?array $classTargets = null)
     {
         if (null === $dsn) {
             $dsn = 'sqlite::memory:';
@@ -145,12 +145,12 @@ class PropelQuickBuilder
         return $this->getPlatform()->getAddTablesDDL($this->getDatabase());
     }
 
-    public function buildClasses(array $classTargets = null)
+    public function buildClasses(?array $classTargets = null)
     {
         eval($this->getClasses($classTargets));
     }
 
-    public function getClasses(array $classTargets = null): string
+    public function getClasses(?array $classTargets = null): string
     {
         $script = '';
         foreach ($this->getDatabase()->getTables() as $table) {
@@ -160,7 +160,7 @@ class PropelQuickBuilder
         return $script;
     }
 
-    public function getClassesForTable(Table $table, array $classTargets = null)
+    public function getClassesForTable(Table $table, ?array $classTargets = null)
     {
         if (null === $classTargets) {
             $classTargets = $this->classTargets;

--- a/runtime/lib/connection/PropelPDO.php
+++ b/runtime/lib/connection/PropelPDO.php
@@ -608,7 +608,7 @@ class PropelPDO extends PDO
      * @param string  $methodName    Name of the method whose execution is being logged.
      * @param array   $debugSnapshot Previous return value from self::getDebugSnapshot().
      */
-    public function log($msg, $level = null, $methodName = null, array $debugSnapshot = null)
+    public function log($msg, $level = null, $methodName = null, ?array $debugSnapshot = null)
     {
         // If logging has been specifically disabled, this method won't do anything
         if (!$this->getLoggingConfig('enabled', true)) {

--- a/runtime/lib/exception/PropelException.php
+++ b/runtime/lib/exception/PropelException.php
@@ -32,7 +32,7 @@ class PropelException extends Exception
      *
      * @return PropelException
      */
-    public function __construct($message = null, Exception $previous = null)
+    public function __construct($message = null, ?Exception $previous = null)
     {
         if ($previous === null && $message instanceof Exception) {
             $previous = $message;

--- a/runtime/lib/formatter/ModelWith.php
+++ b/runtime/lib/formatter/ModelWith.php
@@ -29,7 +29,7 @@ class ModelWith
     protected $leftPhpName;
     protected $rightPhpName;
 
-    public function __construct(ModelJoin $join = null)
+    public function __construct(?ModelJoin $join = null)
     {
         if (null !== $join) {
             $this->init($join);

--- a/runtime/lib/formatter/PropelFormatter.php
+++ b/runtime/lib/formatter/PropelFormatter.php
@@ -26,7 +26,7 @@ abstract class PropelFormatter
         $hasLimit = false,
         $currentObjects = array();
 
-    public function __construct(ModelCriteria $criteria = null)
+    public function __construct(?ModelCriteria $criteria = null)
     {
         if (null !== $criteria) {
             $this->init($criteria);

--- a/runtime/lib/om/BaseObject.php
+++ b/runtime/lib/om/BaseObject.php
@@ -156,7 +156,7 @@ abstract class BaseObject
      *
      * @return boolean
      */
-    public function preSave(PropelPDO $con = null)
+    public function preSave(?PropelPDO $con = null)
     {
         return true;
     }
@@ -166,7 +166,7 @@ abstract class BaseObject
      *
      * @param PropelPDO $con
      */
-    public function postSave(PropelPDO $con = null)
+    public function postSave(?PropelPDO $con = null)
     {
     }
 
@@ -177,7 +177,7 @@ abstract class BaseObject
      *
      * @return boolean
      */
-    public function preInsert(PropelPDO $con = null)
+    public function preInsert(?PropelPDO $con = null)
     {
         return true;
     }
@@ -187,7 +187,7 @@ abstract class BaseObject
      *
      * @param PropelPDO $con
      */
-    public function postInsert(PropelPDO $con = null)
+    public function postInsert(?PropelPDO $con = null)
     {
     }
 
@@ -198,7 +198,7 @@ abstract class BaseObject
      *
      * @return boolean
      */
-    public function preUpdate(PropelPDO $con = null)
+    public function preUpdate(?PropelPDO $con = null)
     {
         return true;
     }
@@ -208,7 +208,7 @@ abstract class BaseObject
      *
      * @param PropelPDO $con
      */
-    public function postUpdate(PropelPDO $con = null)
+    public function postUpdate(?PropelPDO $con = null)
     {
     }
 
@@ -219,7 +219,7 @@ abstract class BaseObject
      *
      * @return boolean
      */
-    public function preDelete(PropelPDO $con = null)
+    public function preDelete(?PropelPDO $con = null)
     {
         return true;
     }
@@ -229,7 +229,7 @@ abstract class BaseObject
      *
      * @param PropelPDO $con
      */
-    public function postDelete(PropelPDO $con = null)
+    public function postDelete(?PropelPDO $con = null)
     {
     }
 

--- a/runtime/lib/om/NodeObject.php
+++ b/runtime/lib/om/NodeObject.php
@@ -26,7 +26,7 @@ interface NodeObject extends IteratorAggregate
      * @return void
      * @throws PropelException
      */
-    public function save(PropelPDO $con = null);
+    public function save(?PropelPDO $con = null);
 
     /**
      * Delete node and descendants
@@ -36,7 +36,7 @@ interface NodeObject extends IteratorAggregate
      * @return void
      * @throws PropelException
      */
-    public function delete(PropelPDO $con = null);
+    public function delete(?PropelPDO $con = null);
 
     /**
      * Sets node properties to make it a root node.
@@ -53,7 +53,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return int
      */
-    public function getLevel(PropelPDO $con = null);
+    public function getLevel(?PropelPDO $con = null);
 
     /**
      * Get the path to the node in the tree
@@ -62,7 +62,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return array
      */
-    public function getPath(PropelPDO $con = null);
+    public function getPath(?PropelPDO $con = null);
 
     /**
      * Gets the number of children for the node (direct descendants)
@@ -71,7 +71,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return int
      */
-    public function getNumberOfChildren(PropelPDO $con = null);
+    public function getNumberOfChildren(?PropelPDO $con = null);
 
     /**
      * Gets the total number of descendants for the node
@@ -80,7 +80,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return int
      */
-    public function getNumberOfDescendants(PropelPDO $con = null);
+    public function getNumberOfDescendants(?PropelPDO $con = null);
 
     /**
      * Gets the children for the node
@@ -89,7 +89,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return array
      */
-    public function getChildren(PropelPDO $con = null);
+    public function getChildren(?PropelPDO $con = null);
 
     /**
      * Gets the descendants for the node
@@ -98,7 +98,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return array
      */
-    public function getDescendants(PropelPDO $con = null);
+    public function getDescendants(?PropelPDO $con = null);
 
     /**
      * Sets the level of the node in the tree
@@ -125,7 +125,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return object The current object (for fluent API support)
      */
-    public function setParentNode(NodeObject $parent = null);
+    public function setParentNode(?NodeObject $parent = null);
 
     /**
      * Sets the previous sibling of the node in the tree
@@ -134,7 +134,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return object The current object (for fluent API support)
      */
-    public function setPrevSibling(NodeObject $node = null);
+    public function setPrevSibling(?NodeObject $node = null);
 
     /**
      * Sets the next sibling of the node in the tree
@@ -143,7 +143,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return object The current object (for fluent API support)
      */
-    public function setNextSibling(NodeObject $node = null);
+    public function setNextSibling(?NodeObject $node = null);
 
     /**
      * Determines if the node is the root node
@@ -175,7 +175,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return bool
      */
-    public function hasParent(PropelPDO $con = null);
+    public function hasParent(?PropelPDO $con = null);
 
     /**
      * Determines if the node has children / descendants
@@ -191,7 +191,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return bool
      */
-    public function hasPrevSibling(PropelPDO $con = null);
+    public function hasPrevSibling(?PropelPDO $con = null);
 
     /**
      * Determines if the node has next sibling
@@ -200,7 +200,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return bool
      */
-    public function hasNextSibling(PropelPDO $con = null);
+    public function hasNextSibling(?PropelPDO $con = null);
 
     /**
      * Gets ancestor for the given node if it exists
@@ -209,7 +209,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return mixed Propel object if exists else false
      */
-    public function retrieveParent(PropelPDO $con = null);
+    public function retrieveParent(?PropelPDO $con = null);
 
     /**
      * Gets first child if it exists
@@ -218,7 +218,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return mixed Propel object if exists else false
      */
-    public function retrieveFirstChild(PropelPDO $con = null);
+    public function retrieveFirstChild(?PropelPDO $con = null);
 
     /**
      * Gets last child if it exists
@@ -227,7 +227,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return mixed Propel object if exists else false
      */
-    public function retrieveLastChild(PropelPDO $con = null);
+    public function retrieveLastChild(?PropelPDO $con = null);
 
     /**
      * Gets prev sibling for the given node if it exists
@@ -236,7 +236,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return mixed Propel object if exists else false
      */
-    public function retrievePrevSibling(PropelPDO $con = null);
+    public function retrievePrevSibling(?PropelPDO $con = null);
 
     /**
      * Gets next sibling for the given node if it exists
@@ -245,7 +245,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return mixed Propel object if exists else false
      */
-    public function retrieveNextSibling(PropelPDO $con = null);
+    public function retrieveNextSibling(?PropelPDO $con = null);
 
     /**
      * Inserts as first child of destination node $parent
@@ -255,7 +255,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return object The current object (for fluent API support)
      */
-    public function insertAsFirstChildOf(NodeObject $parent, PropelPDO $con = null);
+    public function insertAsFirstChildOf(NodeObject $parent, ?PropelPDO $con = null);
 
     /**
      * Inserts as last child of destination node $parent
@@ -265,7 +265,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return object The current object (for fluent API support)
      */
-    public function insertAsLastChildOf(NodeObject $parent, PropelPDO $con = null);
+    public function insertAsLastChildOf(NodeObject $parent, ?PropelPDO $con = null);
 
     /**
      * Inserts node as previous sibling to destination node $dest
@@ -275,7 +275,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return object The current object (for fluent API support)
      */
-    public function insertAsPrevSiblingOf(NodeObject $dest, PropelPDO $con = null);
+    public function insertAsPrevSiblingOf(NodeObject $dest, ?PropelPDO $con = null);
 
     /**
      * Inserts node as next sibling to destination node $dest
@@ -285,7 +285,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return object The current object (for fluent API support)
      */
-    public function insertAsNextSiblingOf(NodeObject $dest, PropelPDO $con = null);
+    public function insertAsNextSiblingOf(NodeObject $dest, ?PropelPDO $con = null);
 
     /**
      * Moves node to be first child of $parent
@@ -295,7 +295,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return void
      */
-    public function moveToFirstChildOf(NodeObject $parent, PropelPDO $con = null);
+    public function moveToFirstChildOf(NodeObject $parent, ?PropelPDO $con = null);
 
     /**
      * Moves node to be last child of $parent
@@ -305,7 +305,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return void
      */
-    public function moveToLastChildOf(NodeObject $parent, PropelPDO $con = null);
+    public function moveToLastChildOf(NodeObject $parent, ?PropelPDO $con = null);
 
     /**
      * Moves node to be prev sibling to $dest
@@ -315,7 +315,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return void
      */
-    public function moveToPrevSiblingOf(NodeObject $dest, PropelPDO $con = null);
+    public function moveToPrevSiblingOf(NodeObject $dest, ?PropelPDO $con = null);
 
     /**
      * Moves node to be next sibling to $dest
@@ -325,7 +325,7 @@ interface NodeObject extends IteratorAggregate
      *
      * @return void
      */
-    public function moveToNextSiblingOf(NodeObject $dest, PropelPDO $con = null);
+    public function moveToNextSiblingOf(NodeObject $dest, ?PropelPDO $con = null);
 
     /**
      * Inserts node as parent of given node.
@@ -336,7 +336,7 @@ interface NodeObject extends IteratorAggregate
      * @return void
      * @throws Exception When trying to insert node as parent of a root node
      */
-    public function insertAsParentOf(NodeObject $node, PropelPDO $con = null);
+    public function insertAsParentOf(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Wraps the getter for the scope value

--- a/runtime/lib/om/Persistent.php
+++ b/runtime/lib/om/Persistent.php
@@ -102,7 +102,7 @@ interface Persistent
      * @return void
      * @throws Exception
      */
-    public function delete(PropelPDO $con = null);
+    public function delete(?PropelPDO $con = null);
 
     /**
      * Saves the object.
@@ -112,5 +112,5 @@ interface Persistent
      * @return void
      * @throws Exception
      */
-    public function save(PropelPDO $con = null);
+    public function save(?PropelPDO $con = null);
 }

--- a/runtime/lib/om/PreOrderNodeIterator.php
+++ b/runtime/lib/om/PreOrderNodeIterator.php
@@ -39,26 +39,27 @@ class PreOrderNodeIterator implements Iterator
         }
     }
 
-    public function rewind()
+    public function rewind(): void
     {
         $this->curNode = $this->topNode;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return ($this->curNode !== null);
     }
 
-    public function current()
+    public function current(): mixed
     {
         return $this->curNode;
     }
 
-    public function key()
+    public function key(): mixed
     {
         return $this->curNode->getNodePath();
     }
 
+    #[\ReturnTypeWillChange]
     public function next()
     {
         if ($this->valid()) {

--- a/runtime/lib/query/CriterionIterator.php
+++ b/runtime/lib/query/CriterionIterator.php
@@ -32,27 +32,28 @@ class CriterionIterator implements Iterator
         $this->criteriaSize = count($this->criteriaKeys);
     }
 
-    public function rewind()
+
+    public function rewind(): void
     {
         $this->idx = 0;
     }
 
-    public function valid()
+    public function valid(): bool
     {
         return $this->idx < $this->criteriaSize;
     }
 
-    public function key()
+    public function key(): mixed
     {
         return $this->criteriaKeys[$this->idx];
     }
 
-    public function current()
+    public function current(): mixed
     {
         return $this->criteria->getCriterion($this->criteriaKeys[$this->idx]);
     }
 
-    public function next()
+    public function next(): void
     {
         $this->idx++;
     }

--- a/runtime/lib/query/ModelCriteria.php
+++ b/runtime/lib/query/ModelCriteria.php
@@ -2337,7 +2337,7 @@ class ModelCriteria extends Criteria
     }
 
     /**
-     * @param PropelPDO $con = null
+     * @param ?PropelPDO $con = null
      *
      * @return boolean
      */

--- a/runtime/lib/util/BasePeer.php
+++ b/runtime/lib/util/BasePeer.php
@@ -464,7 +464,7 @@ class BasePeer
      * @throws PropelException
      * @see        createSelectSql()
      */
-    public static function doSelect(Criteria $criteria, PropelPDO $con = null)
+    public static function doSelect(Criteria $criteria, ?PropelPDO $con = null)
     {
         $dbMap = Propel::getDatabaseMap($criteria->getDbName());
         $db = Propel::getDB($criteria->getDbName());
@@ -506,7 +506,7 @@ class BasePeer
      * @throws PropelException
      * @see        createSelectSql()
      */
-    public static function doCount(Criteria $criteria, PropelPDO $con = null)
+    public static function doCount(Criteria $criteria, ?PropelPDO $con = null)
     {
         $dbMap = Propel::getDatabaseMap($criteria->getDbName());
         $db = Propel::getDB($criteria->getDbName());

--- a/runtime/lib/util/NodePeer.php
+++ b/runtime/lib/util/NodePeer.php
@@ -34,7 +34,7 @@ interface NodePeer
      *
      * @return object Propel object for root node
      */
-    public static function retrieveRoot($scopeId = 1, PropelPDO $con = null);
+    public static function retrieveRoot($scopeId = 1, ?PropelPDO $con = null);
 
     /**
      * Inserts $child as first child of destination node $parent
@@ -45,7 +45,7 @@ interface NodePeer
      *
      * @return void
      */
-    public static function insertAsFirstChildOf(NodeObject $child, NodeObject $parent, PropelPDO $con = null);
+    public static function insertAsFirstChildOf(NodeObject $child, NodeObject $parent, ?PropelPDO $con = null);
 
     /**
      * Inserts $child as last child of destination node $parent
@@ -56,7 +56,7 @@ interface NodePeer
      *
      * @return void
      */
-    public static function insertAsLastChildOf(NodeObject $child, NodeObject $parent, PropelPDO $con = null);
+    public static function insertAsLastChildOf(NodeObject $child, NodeObject $parent, ?PropelPDO $con = null);
 
     /**
      * Inserts $sibling as previous sibling to destination node $node
@@ -67,7 +67,7 @@ interface NodePeer
      *
      * @return void
      */
-    public static function insertAsPrevSiblingOf(NodeObject $node, NodeObject $sibling, PropelPDO $con = null);
+    public static function insertAsPrevSiblingOf(NodeObject $node, NodeObject $sibling, ?PropelPDO $con = null);
 
     /**
      * Inserts $sibling as next sibling to destination node $node
@@ -78,7 +78,7 @@ interface NodePeer
      *
      * @return void
      */
-    public static function insertAsNextSiblingOf(NodeObject $node, NodeObject $sibling, PropelPDO $con = null);
+    public static function insertAsNextSiblingOf(NodeObject $node, NodeObject $sibling, ?PropelPDO $con = null);
 
     /**
      * Inserts $parent as parent of given $node.
@@ -90,7 +90,7 @@ interface NodePeer
      * @return void
      * @throws Exception When trying to insert node as parent of a root node
      */
-    public static function insertAsParentOf(NodeObject $parent, NodeObject $node, PropelPDO $con = null);
+    public static function insertAsParentOf(NodeObject $parent, NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Inserts $node as root node
@@ -100,7 +100,7 @@ interface NodePeer
      *
      * @return void
      */
-    public static function insertRoot(NodeObject $node, PropelPDO $con = null);
+    public static function insertRoot(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Delete root node
@@ -110,7 +110,7 @@ interface NodePeer
      *
      * @return boolean Deletion status
      */
-    public static function deleteRoot($scopeId = 1, PropelPDO $con = null);
+    public static function deleteRoot($scopeId = 1, ?PropelPDO $con = null);
 
     /**
      * Delete $dest node
@@ -120,7 +120,7 @@ interface NodePeer
      *
      * @return boolean Deletion status
      */
-    public static function deleteNode(NodeObject $dest, PropelPDO $con = null);
+    public static function deleteNode(NodeObject $dest, ?PropelPDO $con = null);
 
     /**
      * Moves $child to be first child of $parent
@@ -131,7 +131,7 @@ interface NodePeer
      *
      * @return void
      */
-    public static function moveToFirstChildOf(NodeObject $parent, NodeObject $child, PropelPDO $con = null);
+    public static function moveToFirstChildOf(NodeObject $parent, NodeObject $child, ?PropelPDO $con = null);
 
     /**
      * Moves $node to be last child of $dest
@@ -142,7 +142,7 @@ interface NodePeer
      *
      * @return void
      */
-    public static function moveToLastChildOf(NodeObject $dest, NodeObject $node, PropelPDO $con = null);
+    public static function moveToLastChildOf(NodeObject $dest, NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Moves $node to be prev sibling to $dest
@@ -153,7 +153,7 @@ interface NodePeer
      *
      * @return void
      */
-    public static function moveToPrevSiblingOf(NodeObject $dest, NodeObject $node, PropelPDO $con = null);
+    public static function moveToPrevSiblingOf(NodeObject $dest, NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Moves $node to be next sibling to $dest
@@ -164,7 +164,7 @@ interface NodePeer
      *
      * @return void
      */
-    public static function moveToNextSiblingOf(NodeObject $dest, NodeObject $node, PropelPDO $con = null);
+    public static function moveToNextSiblingOf(NodeObject $dest, NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Gets first child for the given node if it exists
@@ -174,7 +174,7 @@ interface NodePeer
      *
      * @return mixed Propel object if exists else false
      */
-    public static function retrieveFirstChild(NodeObject $node, PropelPDO $con = null);
+    public static function retrieveFirstChild(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Gets last child for the given node if it exists
@@ -184,7 +184,7 @@ interface NodePeer
      *
      * @return mixed Propel object if exists else false
      */
-    public static function retrieveLastChild(NodeObject $node, PropelPDO $con = null);
+    public static function retrieveLastChild(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Gets prev sibling for the given node if it exists
@@ -194,7 +194,7 @@ interface NodePeer
      *
      * @return mixed Propel object if exists else false
      */
-    public static function retrievePrevSibling(NodeObject $node, PropelPDO $con = null);
+    public static function retrievePrevSibling(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Gets next sibling for the given node if it exists
@@ -204,7 +204,7 @@ interface NodePeer
      *
      * @return mixed Propel object if exists else false
      */
-    public static function retrieveNextSibling(NodeObject $node, PropelPDO $con = null);
+    public static function retrieveNextSibling(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Retrieves the entire tree from root
@@ -212,14 +212,14 @@ interface NodePeer
      * @param int       $scopeId Scope id to determine which scope tree to return
      * @param PropelPDO $con     Connection to use.
      */
-    public static function retrieveTree($scopeId = 1, PropelPDO $con = null);
+    public static function retrieveTree($scopeId = 1, ?PropelPDO $con = null);
 
     /**
      * Retrieves the entire tree from parent $node
      *
      * @param PropelPDO $con Connection to use.
      */
-    public static function retrieveBranch(NodeObject $node, PropelPDO $con = null);
+    public static function retrieveBranch(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Gets direct children for the node
@@ -227,7 +227,7 @@ interface NodePeer
      * @param object    $node Propel object for parent node
      * @param PropelPDO $con  Connection to use.
      */
-    public static function retrieveChildren(NodeObject $node, PropelPDO $con = null);
+    public static function retrieveChildren(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Gets all descendants for the node
@@ -235,7 +235,7 @@ interface NodePeer
      * @param object    $node Propel object for parent node
      * @param PropelPDO $con  Connection to use.
      */
-    public static function retrieveDescendants(NodeObject $node, PropelPDO $con = null);
+    public static function retrieveDescendants(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Gets all siblings for the node
@@ -243,7 +243,7 @@ interface NodePeer
      * @param object    $node Propel object for src node
      * @param PropelPDO $con  Connection to use.
      */
-    public static function retrieveSiblings(NodeObject $node, PropelPDO $con = null);
+    public static function retrieveSiblings(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Gets ancestor for the given node if it exists
@@ -253,7 +253,7 @@ interface NodePeer
      *
      * @return mixed Propel object if exists else false
      */
-    public static function retrieveParent(NodeObject $node, PropelPDO $con = null);
+    public static function retrieveParent(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Gets level for the given node
@@ -263,7 +263,7 @@ interface NodePeer
      *
      * @return int Level for the given node
      */
-    public static function getLevel(NodeObject $node, PropelPDO $con = null);
+    public static function getLevel(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Gets number of direct children for given node
@@ -273,7 +273,7 @@ interface NodePeer
      *
      * @return int Level for the given node
      */
-    public static function getNumberOfChildren(NodeObject $node, PropelPDO $con = null);
+    public static function getNumberOfChildren(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Gets number of descendants for given node
@@ -283,7 +283,7 @@ interface NodePeer
      *
      * @return int Level for the given node
      */
-    public static function getNumberOfDescendants(NodeObject $node, PropelPDO $con = null);
+    public static function getNumberOfDescendants(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Returns path to a specific node as an array, useful to create breadcrumbs
@@ -293,7 +293,7 @@ interface NodePeer
      *
      * @return array Array in order of hierarchy
      */
-    public static function getPath(NodeObject $node, PropelPDO $con = null);
+    public static function getPath(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Tests if node is valid
@@ -302,7 +302,7 @@ interface NodePeer
      *
      * @return bool
      */
-    public static function isValid(NodeObject $node = null);
+    public static function isValid(?NodeObject $node = null);
 
     /**
      * Tests if node is a root
@@ -350,7 +350,7 @@ interface NodePeer
      *
      * @return bool
      */
-    public static function hasParent(NodeObject $node, PropelPDO $con = null);
+    public static function hasParent(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Tests if $node has prev sibling
@@ -360,7 +360,7 @@ interface NodePeer
      *
      * @return bool
      */
-    public static function hasPrevSibling(NodeObject $node, PropelPDO $con = null);
+    public static function hasPrevSibling(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Tests if $node has next sibling
@@ -370,7 +370,7 @@ interface NodePeer
      *
      * @return bool
      */
-    public static function hasNextSibling(NodeObject $node, PropelPDO $con = null);
+    public static function hasNextSibling(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Tests if $node has children
@@ -387,7 +387,7 @@ interface NodePeer
      * @param object    $node Propel object for source node
      * @param PropelPDO $con  Connection to use.
      */
-    public static function deleteDescendants(NodeObject $node, PropelPDO $con = null);
+    public static function deleteDescendants(NodeObject $node, ?PropelPDO $con = null);
 
     /**
      * Returns a node given its primary key or the node itself
@@ -397,5 +397,5 @@ interface NodePeer
      *
      * @return object Propel object for model
      */
-    public static function getNode($node, PropelPDO $con = null);
+    public static function getNode($node, ?PropelPDO $con = null);
 } // NodePeer

--- a/runtime/lib/util/PropelDateTime.php
+++ b/runtime/lib/util/PropelDateTime.php
@@ -48,7 +48,7 @@ class PropelDateTime extends DateTime
      *
      * @throws PropelException
      */
-    public static function newInstance($value, DateTimeZone $timeZone = null, $dateTimeClass = 'DateTime')
+    public static function newInstance($value, ?DateTimeZone $timeZone = null, $dateTimeClass = 'DateTime')
     {
         if ($value instanceof DateTime) {
             return $value;

--- a/test/testsuite/generator/behavior/SoftDeleteBehaviorTest.php
+++ b/test/testsuite/generator/behavior/SoftDeleteBehaviorTest.php
@@ -394,7 +394,7 @@ class SoftDeleteBehaviorTest extends BookstoreTestBase
 
 class UndeletableTable4 extends Table4
 {
-    public function preDelete(PropelPDO $con = null): bool
+    public function preDelete(?PropelPDO $con = null): bool
     {
         parent::preDelete($con);
         $this->setTitle('foo');
@@ -405,7 +405,7 @@ class UndeletableTable4 extends Table4
 
 class PostdeletehookedTable4 extends Table4
 {
-    public function postDelete(PropelPDO $con = null)
+    public function postDelete(?PropelPDO $con = null)
     {
         parent::postDelete($con);
         $this->setTitle('post-deleted');

--- a/test/testsuite/generator/behavior/aggregate_column/AggregateColumnBehaviorTest.php
+++ b/test/testsuite/generator/behavior/aggregate_column/AggregateColumnBehaviorTest.php
@@ -265,7 +265,7 @@ class AggregateColumnBehaviorTest extends BookstoreTestBase
 class TestableComment extends AggregateComment
 {
     // overrides the parent save() to bypass behavior hooks
-    public function save(PropelPDO $con = null)
+    public function save(?PropelPDO $con = null)
     {
         $con->beginTransaction();
         try {
@@ -281,7 +281,7 @@ class TestableComment extends AggregateComment
     }
 
     // overrides the parent delete() to bypass behavior hooks
-    public function delete(PropelPDO $con = null)
+    public function delete(?PropelPDO $con = null)
     {
         $con->beginTransaction();
         try {

--- a/test/testsuite/generator/builder/om/GeneratedObjectTest.php
+++ b/test/testsuite/generator/builder/om/GeneratedObjectTest.php
@@ -1726,7 +1726,7 @@ class CountableAuthor extends Author
     /**
      * {@inheritdoc}
      */
-    public function preSave(PropelPDO $con = null)
+    public function preSave(?PropelPDO $con = null)
     {
         $this->nbCallPreSave++;
 

--- a/test/tools/helpers/bookstore/behavior/TestAuthor.php
+++ b/test/tools/helpers/bookstore/behavior/TestAuthor.php
@@ -10,7 +10,7 @@
 
 class TestAuthor extends Author
 {
-    public function preInsert(PropelPDO $con = null)
+    public function preInsert(?PropelPDO $con = null)
     {
         parent::preInsert($con);
         $this->setFirstName('PreInsertedFirstname');
@@ -18,13 +18,13 @@ class TestAuthor extends Author
         return true;
     }
 
-    public function postInsert(PropelPDO $con = null)
+    public function postInsert(?PropelPDO $con = null)
     {
         parent::postInsert($con);
         $this->setLastName('PostInsertedLastName');
     }
 
-    public function preUpdate(PropelPDO $con = null)
+    public function preUpdate(?PropelPDO $con = null)
     {
         parent::preUpdate($con);
         $this->setFirstName('PreUpdatedFirstname');
@@ -32,13 +32,13 @@ class TestAuthor extends Author
         return true;
     }
 
-    public function postUpdate(PropelPDO $con = null)
+    public function postUpdate(?PropelPDO $con = null)
     {
         parent::postUpdate($con);
         $this->setLastName('PostUpdatedLastName');
     }
 
-    public function preSave(PropelPDO $con = null)
+    public function preSave(?PropelPDO $con = null)
     {
         parent::preSave($con);
         $this->setEmail("pre@save.com");
@@ -46,13 +46,13 @@ class TestAuthor extends Author
         return true;
     }
 
-    public function postSave(PropelPDO $con = null)
+    public function postSave(?PropelPDO $con = null)
     {
         parent::postSave($con);
         $this->setAge(115);
     }
 
-    public function preDelete(PropelPDO $con = null)
+    public function preDelete(?PropelPDO $con = null)
     {
         parent::preDelete($con);
         $this->setFirstName("Pre-Deleted");
@@ -60,7 +60,7 @@ class TestAuthor extends Author
         return true;
     }
 
-    public function postDelete(PropelPDO $con = null)
+    public function postDelete(?PropelPDO $con = null)
     {
         parent::postDelete($con);
         $this->setLastName("Post-Deleted");
@@ -75,7 +75,7 @@ class TestAuthor extends Author
 
 class TestAuthorDeleteFalse extends TestAuthor
 {
-    public function preDelete(PropelPDO $con = null): bool
+    public function preDelete(?PropelPDO $con = null): bool
     {
         parent::preDelete($con);
         $this->setFirstName("Pre-Deleted");
@@ -85,7 +85,7 @@ class TestAuthorDeleteFalse extends TestAuthor
 }
 class TestAuthorSaveFalse extends TestAuthor
 {
-    public function preSave(PropelPDO $con = null): bool
+    public function preSave(?PropelPDO $con = null): bool
     {
         parent::preSave($con);
         $this->setEmail("pre@save.com");


### PR DESCRIPTION
This primarily handles the deprecation of implicitly nullable parameter declarations.
Also adds return types to some iterators; one method should return `void` but it seems to return a value so I've used `#[\ReturnTypeWillChange]` on that one.